### PR TITLE
Add Session and transaction management utilities to simplify testing

### DIFF
--- a/orm/hibernate-orm-4/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
+++ b/orm/hibernate-orm-4/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
@@ -1,17 +1,20 @@
 package org.hibernate.bugs;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.service.ServiceRegistry;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * This template demonstrates how to develop a standalone test case for Hibernate ORM.  Although this is perfectly
  * acceptable as a reproducer, usage of ORMUnitTestCase is preferred!
  */
-public class ORMStandaloneTestCase {
+public abstract class ORMStandaloneTestCase {
 
 	private Configuration cfg;
 
@@ -37,7 +40,122 @@ public class ORMStandaloneTestCase {
 	// Add your tests, using standard JUnit.
 
 	@Test
+	@Ignore
 	public void hhh123Test() throws Exception {
 
 	}
+
+    /**
+     * Execute the given logic in a transactional context.
+     * The Session and the Transaction are automatically managed.
+     *
+     * @param executable unit of logic
+     * @param <T> result type
+     * @return result
+     */
+    protected <T> T doInTransaction(TransactionExecutable<T> executable) {
+        T result = null;
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            executable.beforeTransactionCompletion();
+            txn = session.beginTransaction();
+
+            result = executable.execute(session);
+            txn.commit();
+        } catch (RuntimeException e) {
+            if ( txn != null && txn.isActive() ) txn.rollback();
+            throw e;
+        } finally {
+            executable.afterTransactionCompletion();
+            if (session != null) {
+                session.close();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Execute the given logic in a transactional context.
+     * The Session and the Transaction are automatically managed.
+     *
+     * @param executable unit of logic
+     */
+    protected void doInTransaction(TransactionVoidExecutable executable) {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            executable.beforeTransactionCompletion();
+            txn = session.beginTransaction();
+
+            executable.execute(session);
+            txn.commit();
+        } catch (RuntimeException e) {
+            if ( txn != null && txn.isActive() ) txn.rollback();
+            throw e;
+        } finally {
+            executable.afterTransactionCompletion();
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    /**
+     * Executable unit that may return a result.
+     * @param <T> result type
+     */
+    protected interface Executable<T> {
+        /**
+         * Execute against the given Session
+         * @param session Hibernate session
+         * @return result
+         */
+        T execute(Session session);
+    }
+
+    /**
+     * Executable unit that doesn't return a result.
+     */
+    protected interface VoidExecutable {
+        /**
+         * Execute against the given Session
+         * @param session Hibernate session
+         */
+        void execute(Session session);
+    }
+
+    protected abstract class TransactionExecutable<T> implements Executable<T> {
+        /**
+         * Before transaction completion callback
+         */
+        void beforeTransactionCompletion() {
+
+        }
+
+        /**
+         * After transaction completion callback
+         */
+        void afterTransactionCompletion() {
+
+        }
+    }
+
+    protected abstract class TransactionVoidExecutable implements VoidExecutable {
+        /**
+         * Before transaction completion callback
+         */
+        void beforeTransactionCompletion() {
+
+        }
+
+        /**
+         * After transaction completion callback
+         */
+        void afterTransactionCompletion() {
+
+        }
+    }
 }

--- a/orm/hibernate-orm-4/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
+++ b/orm/hibernate-orm-4/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
@@ -19,6 +19,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -30,7 +31,7 @@ import org.junit.Test;
  * What's even better?  Fork hibernate-orm itself, add your test case directly to a module's unit tests, then
  * submit it as a PR!
  */
-public class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
+public abstract class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
 
 	// Add your entities here.
 	@Override
@@ -65,6 +66,7 @@ public class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
 
 	// Add your tests, using standard JUnit.
 	@Test
+	@Ignore
 	public void hhh123Test() throws Exception {
 		// BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
 		Session s = openSession();
@@ -73,4 +75,118 @@ public class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
 		tx.commit();
 		s.close();
 	}
+
+    /**
+     * Execute the given logic in a transactional context.
+     * The Session and the Transaction are automatically managed.
+     *
+     * @param executable unit of logic
+     * @param <T> result type
+     * @return result
+     */
+    protected <T> T doInTransaction(TransactionExecutable<T> executable) {
+        T result = null;
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sessionFactory().openSession();
+            executable.beforeTransactionCompletion();
+            txn = session.beginTransaction();
+
+            result = executable.execute(session);
+            txn.commit();
+        } catch (RuntimeException e) {
+            if ( txn != null && txn.isActive() ) txn.rollback();
+            throw e;
+        } finally {
+            executable.afterTransactionCompletion();
+            if (session != null) {
+                session.close();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Execute the given logic in a transactional context.
+     * The Session and the Transaction are automatically managed.
+     *
+     * @param executable unit of logic
+     */
+    protected void doInTransaction(TransactionVoidExecutable executable) {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sessionFactory().openSession();
+            executable.beforeTransactionCompletion();
+            txn = session.beginTransaction();
+
+            executable.execute(session);
+            txn.commit();
+        } catch (RuntimeException e) {
+            if ( txn != null && txn.isActive() ) txn.rollback();
+            throw e;
+        } finally {
+            executable.afterTransactionCompletion();
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    /**
+     * Executable unit that may return a result.
+     * @param <T> result type
+     */
+    protected interface Executable<T> {
+        /**
+         * Execute against the given Session
+         * @param session Hibernate session
+         * @return result
+         */
+        T execute(Session session);
+    }
+
+    /**
+     * Executable unit that doesn't return a result.
+     */
+    protected interface VoidExecutable {
+        /**
+         * Execute against the given Session
+         * @param session Hibernate session
+         */
+        void execute(Session session);
+    }
+
+    protected abstract class TransactionExecutable<T> implements Executable<T> {
+        /**
+         * Before transaction completion callback
+         */
+        void beforeTransactionCompletion() {
+
+        }
+
+        /**
+         * After transaction completion callback
+         */
+        void afterTransactionCompletion() {
+
+        }
+    }
+
+    protected abstract class TransactionVoidExecutable implements VoidExecutable {
+        /**
+         * Before transaction completion callback
+         */
+        void beforeTransactionCompletion() {
+
+        }
+
+        /**
+         * After transaction completion callback
+         */
+        void afterTransactionCompletion() {
+
+        }
+    }
 }

--- a/orm/hibernate-orm-4/src/test/java/org/hibernate/bugs/PrototypeTestCase.java
+++ b/orm/hibernate-orm-4/src/test/java/org/hibernate/bugs/PrototypeTestCase.java
@@ -1,0 +1,83 @@
+package org.hibernate.bugs;
+
+import org.hibernate.Session;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * <code>PrototypeTestCase</code> - Prototype TestCase
+ *
+ * @author Vlad Mihalcea
+ */
+public class PrototypeTestCase extends ORMUnitTestCase {
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] {
+                Repository.class
+        };
+    }
+
+    @Test
+    public void hhh_123() {
+
+        doInTransaction(new TransactionVoidExecutable() {
+            @Override
+            public void execute(Session session) {
+                Repository repository = new Repository("Hibernate Test Case Template");
+                repository.setId(1L);
+                session.save(repository);
+            }
+        });
+
+        Repository repository = doInTransaction(new TransactionExecutable<Repository>() {
+            @Override
+            public Repository execute(Session session) {
+                return (Repository) session.get(Repository.class, 1L);
+            }
+        });
+    }
+
+    /**
+     * Repository - Repository
+     *
+     * @author Vlad Mihalcea
+     */
+    @Entity(name = "Repository")
+    public static class Repository {
+
+        @Id
+        private Long id;
+
+        private String name;
+
+        public Repository() {
+        }
+
+        public Repository(Long id) {
+            this.id = id;
+        }
+
+        public Repository(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
+}

--- a/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
+++ b/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
@@ -1,17 +1,20 @@
 package org.hibernate.bugs;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * This template demonstrates how to develop a standalone test case for Hibernate ORM.  Although this is perfectly
  * acceptable as a reproducer, usage of ORMUnitTestCase is preferred!
  */
-public class ORMStandaloneTestCase {
+public abstract class ORMStandaloneTestCase {
 
 	private SessionFactory sf;
 
@@ -34,7 +37,122 @@ public class ORMStandaloneTestCase {
 	// Add your tests, using standard JUnit.
 
 	@Test
+	@Ignore
 	public void hhh123Test() throws Exception {
 
+	}
+
+	/**
+	 * Execute the given logic in a transactional context.
+	 * The Session and the Transaction are automatically managed.
+	 *
+	 * @param executable unit of logic
+	 * @param <T> result type
+	 * @return result
+	 */
+	protected <T> T doInTransaction(TransactionExecutable<T> executable) {
+		T result = null;
+		Session session = null;
+		Transaction txn = null;
+		try {
+			session = sf.openSession();
+			executable.beforeTransactionCompletion();
+			txn = session.beginTransaction();
+
+			result = executable.execute(session);
+			txn.commit();
+		} catch (RuntimeException e) {
+			if ( txn != null ) txn.rollback();
+			throw e;
+		} finally {
+			executable.afterTransactionCompletion();
+			if (session != null) {
+				session.close();
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Execute the given logic in a transactional context.
+	 * The Session and the Transaction are automatically managed.
+	 *
+	 * @param executable unit of logic
+	 */
+	protected void doInTransaction(TransactionVoidExecutable executable) {
+		Session session = null;
+		Transaction txn = null;
+		try {
+			session = sf.openSession();
+			executable.beforeTransactionCompletion();
+			txn = session.beginTransaction();
+
+			executable.execute(session);
+			txn.commit();
+		} catch (RuntimeException e) {
+			if ( txn != null ) txn.rollback();
+			throw e;
+		} finally {
+			executable.afterTransactionCompletion();
+			if (session != null) {
+				session.close();
+			}
+		}
+	}
+
+	/**
+	 * Executable unit that may return a result.
+	 * @param <T> result type
+	 */
+	protected interface Executable<T> {
+		/**
+		 * Execute against the given Session
+		 * @param session Hibernate session
+		 * @return result
+		 */
+		T execute(Session session);
+	}
+
+	/**
+	 * Executable unit that doesn't return a result.
+	 */
+	protected interface VoidExecutable {
+		/**
+		 * Execute against the given Session
+		 * @param session Hibernate session
+		 */
+		void execute(Session session);
+	}
+
+	protected abstract class TransactionExecutable<T> implements Executable<T> {
+		/**
+		 * Before transaction completion callback
+		 */
+		void beforeTransactionCompletion() {
+
+		}
+
+		/**
+		 * After transaction completion callback
+		 */
+		void afterTransactionCompletion() {
+
+		}
+	}
+
+	protected abstract class TransactionVoidExecutable implements VoidExecutable {
+		/**
+		 * Before transaction completion callback
+		 */
+		void beforeTransactionCompletion() {
+
+		}
+
+		/**
+		 * After transaction completion callback
+		 */
+		void afterTransactionCompletion() {
+
+		}
 	}
 }

--- a/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/PrototypeTestCase.java
+++ b/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/PrototypeTestCase.java
@@ -1,0 +1,75 @@
+package org.hibernate.bugs;
+
+import org.hibernate.Session;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * <code>PrototypeTestCase</code> - Prototype TestCase
+ *
+ * @author Vlad Mihalcea
+ */
+public class PrototypeTestCase extends ORMUnitTestCase {
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] {
+                Repository.class
+        };
+    }
+
+    @Test
+    public void hhh_123() {
+
+        doInTransaction(session -> {
+            Repository repository = new Repository("Hibernate Test Case Template");
+            repository.setId(1L);
+            session.save(repository);
+        });
+
+        Repository repository = doInTransaction(session -> (Repository) session.get(Repository.class, 1L));
+    }
+
+    /**
+     * Repository - Repository
+     *
+     * @author Vlad Mihalcea
+     */
+    @Entity(name = "Repository")
+    public static class Repository {
+
+        @Id
+        private Long id;
+
+        private String name;
+
+        public Repository() {
+        }
+
+        public Repository(Long id) {
+            this.id = id;
+        }
+
+        public Repository(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
+}


### PR DESCRIPTION
Add base class utilities to decouple the issue logic from the Hibernate Session and Transaction semantics.
The PrototypeTestCase is an example for what we gain from these utilities.