### PR TITLE
Added a testclass to demonstrate the bug in index creation data generat…

### DIFF
--- a/search/hibernate-search-elasticsearch/pom.xml
+++ b/search/hibernate-search-elasticsearch/pom.xml
@@ -80,6 +80,23 @@
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>${version.org.slf4j}</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/bugs/YourAnnotatedEntity.java
+++ b/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/bugs/YourAnnotatedEntity.java
@@ -1,11 +1,11 @@
 package org.hibernate.search.bugs;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
 
 @Entity
 @Indexed

--- a/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/EntityA.java
+++ b/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/EntityA.java
@@ -1,0 +1,56 @@
+package org.hibernate.search.es.dynamicshard.index.bug;
+
+import javax.persistence.*;
+import java.util.Date;
+
+/**
+ * Created by D-YW44CN on 1/07/2016.
+ */
+@Entity
+public class EntityA {
+    @Id
+    private Long id;
+
+    private Date dateType;
+
+    private String type;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "B_IDE", nullable = false)
+    private EntityB entityB;
+
+    public EntityA(Long id, Date date, String val, EntityB entityB) {
+        this.id = id;
+        this.dateType = date;
+        this.entityB = entityB;
+        this.type = val;
+    }
+
+    public EntityA() {
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Date getDateType() {
+        return dateType;
+    }
+
+    public void setDateType(Date dateType) {
+        this.dateType = dateType;
+    }
+
+    public EntityB getEntityB() {
+        return entityB;
+    }
+
+    public void setEntityB(EntityB entityB) {
+        this.entityB = entityB;
+    }
+}

--- a/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/EntityAShardIdentifierProvider.java
+++ b/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/EntityAShardIdentifierProvider.java
@@ -1,0 +1,66 @@
+package org.hibernate.search.es.dynamicshard.index.bug;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Transformer;
+import org.apache.lucene.document.Document;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Property;
+import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.hcore.impl.HibernateSessionFactoryService;
+import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.store.ShardIdentifierProviderTemplate;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.*;
+
+/**
+ * Created by D-YW44CN on 21/06/2016.
+ */
+public class EntityAShardIdentifierProvider extends ShardIdentifierProviderTemplate {
+
+
+
+    @Override
+    protected Set<String> loadInitialShardNames(Properties properties, BuildContext buildContext) {
+        ServiceManager serviceManager = buildContext.getServiceManager();
+        SessionFactory sessionFactory = (SessionFactory) serviceManager.requestService(
+                HibernateSessionFactoryService.class).getSessionFactory();
+        Session session = sessionFactory.openSession();
+        try {
+            Criteria initialShardsCriteria = session.createCriteria(EntityA.class);
+            initialShardsCriteria.setProjection( Projections.distinct(Property.forName("dateType")));
+
+            @SuppressWarnings("unchecked")
+            List<String> initialTypes = initialShardsCriteria.list();
+            Collection returnList = CollectionUtils.collect(initialTypes, new Transformer() {
+                @Override
+                public Object transform(Object o) {
+                    String inputString = ((Timestamp) o).toString();
+                    String result = inputString.substring(0, inputString.indexOf("-"));
+                    return result;
+                }
+            });
+            Set<String> returnSet = new HashSet<String>();
+            returnSet.addAll(returnList);
+            return returnSet;
+        }
+        finally {
+            session.close();
+        }
+    }
+
+    @Override
+    public String getShardIdentifier(Class<?> entityType, Serializable serializable, String s, Document document) {
+        if ( entityType.equals(EntityA.class) ) {
+            String type = document.getField("dateType").stringValue();
+            type = type.substring(0, type.indexOf("-"));
+            addShard(type);
+            return type;
+        }
+        throw new RuntimeException("EntityA expected but found " + entityType);
+    }
+}

--- a/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/EntityB.java
+++ b/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/EntityB.java
@@ -1,0 +1,41 @@
+package org.hibernate.search.es.dynamicshard.index.bug;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.List;
+
+/**
+ * Created by D-YW44CN on 1/07/2016.
+ */
+@Entity
+public class EntityB {
+    @Id
+    private Long id;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "entityB")
+    private List<EntityA> entityAList;
+
+    public EntityB(Long id) {
+        this.id = id;
+    }
+
+    public EntityB() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public List<EntityA> getEntityAList() {
+        return entityAList;
+    }
+
+    public void setEntityAList(List<EntityA> entityAList) {
+        this.entityAList = entityAList;
+    }
+}

--- a/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/IndexWithDSEnabledIT.java
+++ b/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/IndexWithDSEnabledIT.java
@@ -1,0 +1,95 @@
+package org.hibernate.search.es.dynamicshard.index.bug;
+
+import org.apache.lucene.search.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.cfg.SearchMapping;
+import org.hibernate.search.elasticsearch.ElasticsearchQueries;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.engine.spi.QueryDescriptor;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by D-YW44CN on 1/07/2016.
+ */
+public class IndexWithDSEnabledIT extends SearchTestBase {
+    @Override
+    public Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{ EntityA.class, EntityB.class };
+    }
+
+    @Test
+    @TestForIssue(jiraKey = "HSEARCH-NNNNN") // Please fill in the JIRA key of your issue
+    @SuppressWarnings("unchecked")
+    public void testYourBug() throws IOException {
+        Session s = getSessionFromConfig();
+
+        EntityB entityB = new EntityB(1L);
+        EntityA entityA = new EntityA(1L, new Date(), "dummy", entityB);
+        entityB.setEntityAList(Collections.singletonList(entityA));
+
+
+        Transaction tx = s.beginTransaction();
+        s.persist( entityB );
+        s.persist( entityA );
+        tx.commit();
+
+        FullTextSession session = Search.getFullTextSession( s );
+
+        QueryBuilder qb = session.getSearchFactory().buildQueryBuilder().forEntity( EntityA.class ).get();
+        Query query = qb.keyword().onField("type").matching("dummy").createQuery();
+
+        List<EntityA> result = (List<EntityA>) session.createFullTextQuery( query ).list();
+
+        assertEquals( 1, result.size() );
+        assertEquals( 1, (long) result.get( 0 ).getId() );
+
+        s.close();
+    }
+
+    @After
+    public void deleteTestData() {
+        Session s = getSessionFromConfig();
+        FullTextSession session = Search.getFullTextSession( s );
+        Transaction tx = s.beginTransaction();
+
+        QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match_all' : {} } }" );
+        List<?> result = session.createFullTextQuery( query, EntityA.class ).list();
+
+        for ( Object entity : result ) {
+            session.delete( entity );
+        }
+
+        result = session.createFullTextQuery( query, EntityB.class ).list();
+
+        for ( Object entity : result ) {
+            session.delete( entity );
+        }
+
+        tx.commit();
+        s.close();
+    }
+
+    private Session getSessionFromConfig() {
+        SearchMapping mapping = MyAppSearchMappingFactory.getSearchMapping();
+        Configuration config = new Configuration();
+        config.addAnnotatedClass(EntityB.class)
+                .addAnnotatedClass(EntityA.class)
+                .getProperties().put("hibernate.search.model_mapping", mapping);
+        return config.buildSessionFactory().openSession();
+    }
+
+}

--- a/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/MyAppSearchMappingFactory.java
+++ b/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/es/dynamicshard/index/bug/MyAppSearchMappingFactory.java
@@ -1,0 +1,37 @@
+package org.hibernate.search.es.dynamicshard.index.bug;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Resolution;
+import org.hibernate.search.annotations.Store;
+import org.hibernate.search.cfg.SearchMapping;
+
+import java.lang.annotation.ElementType;
+
+/**
+ * Created by D-YW44CN on 1/07/2016.
+ */
+public class MyAppSearchMappingFactory {
+
+    public static SearchMapping getSearchMapping() {
+        SearchMapping mapping = new SearchMapping();
+        mapping.entity(EntityA.class).indexed().indexName("entityA")
+                .property("dateType", ElementType.FIELD).dateBridge(Resolution.SECOND)
+                .field()
+                .store(Store.YES)
+                .analyze(Analyze.NO)
+                .property("type", ElementType.FIELD)
+                .field()
+                .store(Store.YES)
+                .analyze(Analyze.NO)
+                .property("entityB", ElementType.FIELD)
+                .indexEmbedded()
+                .entity(EntityB.class).indexed()
+                .property("id", ElementType.FIELD).documentId().name("arrId")
+                .field()
+                .store(Store.YES)
+                .analyze(Analyze.NO)
+        ;
+
+        return mapping;
+    }
+}

--- a/search/hibernate-search-elasticsearch/src/test/resources/hibernate.properties
+++ b/search/hibernate-search-elasticsearch/src/test/resources/hibernate.properties
@@ -13,7 +13,7 @@ hibernate.connection.username sa
 
 hibernate.connection.pool_size 5
 
-hibernate.show_sql false
+hibernate.show_sql true
 hibernate.format_sql true
 
 hibernate.hbm2ddl.auto create-drop
@@ -23,5 +23,6 @@ hibernate.search.default.indexmanager elasticsearch
 hibernate.search.default.elasticsearch.host http://127.0.0.1:9200
 hibernate.search.default.elasticsearch.index_schema_management_strategy CREATE_DELETE
 hibernate.search.default.elasticsearch.index_management_wait_timeout 10000
-hibernate.search.default.elasticsearch.required_index_status green
+hibernate.search.default.elasticsearch.required_index_status yellow
 hibernate.search.default.elasticsearch.refresh_after_write true
+hibernate.search.entityA.sharding_strategy org.hibernate.search.es.dynamicshard.index.bug.EntityAShardIdentifierProvider

--- a/search/hibernate-search-elasticsearch/src/test/resources/log4j.properties
+++ b/search/hibernate-search-elasticsearch/src/test/resources/log4j.properties
@@ -1,8 +1,9 @@
 # Root logger option
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=DEBUG, stdout
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.logger.org.hibernate=DEBUG


### PR DESCRIPTION
…ed by hibernatesearch - elastissearch integration with dynamic sharding enabled.

There is a new property added to hibernate.properties file to enable dynamic sharding. When that property is enabled, we can see that the testcase org.hibernate.search.es.dynamicshard.index.bug.IndexWithDSEnabledIT.testYourBug() fails when asserting on the result from hibernate search query. On the other hand the same assertion passes when the sharding is disabled.

We can see the difference between the two scenarios in the generated index data with logger level set to DEBUG