### PR TITLE
Restore compatibility with Hibernate ORM 5.0/5.1 in the Hibernate 5 test case template

### DIFF
--- a/orm/hibernate-orm-5/pom.xml
+++ b/orm/hibernate-orm-5/pom.xml
@@ -41,6 +41,18 @@
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>${version.org.slf4j}</version>
 		</dependency>
+
+		<!-- Not necessary for ORM 5.2 and above -->
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<version>${version.org.hibernate}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-java8</artifactId>
+			<version>${version.org.hibernate}</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
See #14.

Partial revert of 3236d68af9c9459a662a02e25061ecaffe4ac4c7.

It seems hibernate-entitymanager isn't required as a dependency anymore
in Hibernate ORM 5.2, but everything works even when it's there. Thus
we'd better keep it so that users wanting to test something on 5.0/5.1
have an easier time.