### PR TITLE
Make Hibernate Search tests simpler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+sudo: required
+dist: trusty
+language: java
+jdk:
+  - oraclejdk8
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+env:
+  global:
+    - PROJECTS=$( find . -name pom.xml -print -or -path '*/target/*' -prune | sort | xargs -n 1 dirname )
+cache:
+  directories:
+    - $HOME/.m2
+install:
+  # The Maven install provided by Travis is outdated, use Maven wrapper to get the latest version
+  - mvn -N io.takari:maven:wrapper
+  - ./mvnw -v
+  # first run to download all the Maven dependencies without logging
+  - MVNW=$( readlink -f ./mvnw ) ;
+    for project in $PROJECTS ;
+    do
+        pushd "$project" ;
+        $MVNW -B -q clean package -DskipTests=true || exit $? ;
+        popd ;
+    done
+script:
+  - MVNW=$( readlink -f ./mvnw ) ;
+    for project in $PROJECTS ;
+    do
+        pushd "$project" ;
+        $MVNW clean verify || exit $? ;
+        popd ;
+    done

--- a/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/bugs/SearchTestBase.java
+++ b/search/hibernate-search-elasticsearch/src/test/java/org/hibernate/search/bugs/SearchTestBase.java
@@ -1,0 +1,46 @@
+package org.hibernate.search.bugs;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.junit.After;
+import org.junit.Before;
+
+public abstract class SearchTestBase {
+	
+	private SessionFactory sessionFactory;
+	
+	@Before
+	public void setUp() {
+		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder();
+		ServiceRegistryImplementor serviceRegistry = (ServiceRegistryImplementor) registryBuilder.build();
+
+		MetadataSources ms = new MetadataSources( serviceRegistry );
+		Class<?>[] annotatedClasses = getAnnotatedClasses();
+		if ( annotatedClasses != null ) {
+			for ( Class<?> entity : annotatedClasses ) {
+				ms.addAnnotatedClass( entity );
+			}
+		}
+
+		Metadata metadata = ms.buildMetadata();
+
+		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
+		this.sessionFactory = sfb.build();
+	}
+	
+	@After
+	public void tearDown() {
+		this.sessionFactory.close();
+	}
+
+	protected abstract Class<?>[] getAnnotatedClasses();
+	
+	protected SessionFactory getSessionFactory() {
+		return sessionFactory;
+	}
+
+}

--- a/search/hibernate-search-lucene/src/test/java/org/hibernate/search/bugs/SearchTestBase.java
+++ b/search/hibernate-search-lucene/src/test/java/org/hibernate/search/bugs/SearchTestBase.java
@@ -1,0 +1,46 @@
+package org.hibernate.search.bugs;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.junit.After;
+import org.junit.Before;
+
+public abstract class SearchTestBase {
+	
+	private SessionFactory sessionFactory;
+	
+	@Before
+	public void setUp() {
+		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder();
+		ServiceRegistryImplementor serviceRegistry = (ServiceRegistryImplementor) registryBuilder.build();
+
+		MetadataSources ms = new MetadataSources( serviceRegistry );
+		Class<?>[] annotatedClasses = getAnnotatedClasses();
+		if ( annotatedClasses != null ) {
+			for ( Class<?> entity : annotatedClasses ) {
+				ms.addAnnotatedClass( entity );
+			}
+		}
+
+		Metadata metadata = ms.buildMetadata();
+
+		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
+		this.sessionFactory = sfb.build();
+	}
+	
+	@After
+	public void tearDown() {
+		this.sessionFactory.close();
+	}
+
+	protected abstract Class<?>[] getAnnotatedClasses();
+	
+	protected SessionFactory getSessionFactory() {
+		return sessionFactory;
+	}
+
+}

--- a/search/hibernate-search-lucene/src/test/java/org/hibernate/search/bugs/YourTestCase.java
+++ b/search/hibernate-search-lucene/src/test/java/org/hibernate/search/bugs/YourTestCase.java
@@ -10,7 +10,6 @@ import org.hibernate.Transaction;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
-import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.Test;
 
@@ -25,25 +24,23 @@ public class YourTestCase extends SearchTestBase {
 	@TestForIssue(jiraKey = "HSEARCH-NNNNN") // Please fill in the JIRA key of your issue
 	@SuppressWarnings("unchecked")
 	public void testYourBug() {
-		Session s = openSession();
-
-		YourAnnotatedEntity yourEntity1 = new YourAnnotatedEntity( 1L, "example" );
-		YourAnnotatedEntity yourEntity2 = new YourAnnotatedEntity( 2L, "test" );
-
-		Transaction tx = s.beginTransaction();
-		s.persist( yourEntity1 );
-		s.persist( yourEntity2 );
-		tx.commit();
-
-		FullTextSession session = Search.getFullTextSession( s );
-		QueryBuilder qb = session.getSearchFactory().buildQueryBuilder().forEntity( YourAnnotatedEntity.class ).get();
-		Query query = qb.keyword().onField( "name" ).matching( "example" ).createQuery();
-
-		List<YourAnnotatedEntity> result = (List<YourAnnotatedEntity>) session.createFullTextQuery( query ).list();
-		assertEquals( 1, result.size() );
-		assertEquals( 1l, (long) result.get( 0 ).getId() );
-
-		s.close();
+		try ( Session s = getSessionFactory().openSession() ) {
+			YourAnnotatedEntity yourEntity1 = new YourAnnotatedEntity( 1L, "example" );
+			YourAnnotatedEntity yourEntity2 = new YourAnnotatedEntity( 2L, "test" );
+	
+			Transaction tx = s.beginTransaction();
+			s.persist( yourEntity1 );
+			s.persist( yourEntity2 );
+			tx.commit();
+	
+			FullTextSession session = Search.getFullTextSession( s );
+			QueryBuilder qb = session.getSearchFactory().buildQueryBuilder().forEntity( YourAnnotatedEntity.class ).get();
+			Query query = qb.keyword().onField( "name" ).matching( "example" ).createQuery();
+	
+			List<YourAnnotatedEntity> result = (List<YourAnnotatedEntity>) session.createFullTextQuery( query ).list();
+			assertEquals( 1, result.size() );
+			assertEquals( 1l, (long) result.get( 0 ).getId() );
+		}
 	}
 
 }

--- a/search/hibernate-search-lucene/src/test/resources/hibernate.properties
+++ b/search/hibernate-search-lucene/src/test/resources/hibernate.properties
@@ -19,4 +19,4 @@ hibernate.format_sql true
 hibernate.hbm2ddl.auto=create-drop
 
 # Hibernate Search configuration
-hibernate.search.default.directory_provider=org.hibernate.search.store.RAMDirectoryProvider
+hibernate.search.default.directory_provider=ram


### PR DESCRIPTION
The main goal here was to not rely on our internal testing infrastructure anymore, at least not by default. 

That way, if we have strange errors due to mismatches between our testing infrastructure and a given version of Hibernate ORM (as seen [here](https://hibernate.atlassian.net/browse/HSEARCH-2541)), the users trying to simply set up their test case won't be bothered.

Also, the test case will become more understandable for users that do not spend their days crawling through the Hibernate Search codebase...

I took this opportunity to add a .travis.yml, which may help users who fork this repository to implement their test case.