### PR TITLE
testcase to reproduce HHH-12436

### DIFF
--- a/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/HHH12436/OneToOnePropertyTestCase.java
+++ b/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/HHH12436/OneToOnePropertyTestCase.java
@@ -1,0 +1,92 @@
+package org.hibernate.bugs.HHH12436;
+
+import javax.persistence.EntityManager;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * In case of Hibernate version
+ * <ul>
+ * <li>5.2.14.Final</li>
+ * <li>5.2.15.Final</li>
+ * <li>5.2.16.Final</li>
+ * </ul>
+ * this test will fail with
+ * <pre>
+ * org.hibernate.id.IdentifierGenerationException: attempted to assign id from null one-to-one property [models.Secunda.parent]
+ * </pre>
+ *
+ * Good versions are
+ * <ul>
+ * <li>5.2.12.Final</li>
+ * <li>5.2.13.Final</li>
+ * </ul>
+ *
+ * @author localEvg
+ */
+public class OneToOnePropertyTestCase {
+
+    private SessionFactory sf;
+
+    @Before
+    public void setup() {
+        StandardServiceRegistryBuilder srb = new StandardServiceRegistryBuilder()
+                // Add in any settings that are specific to your test. See resources/hibernate.properties for the defaults.
+                .applySetting("hibernate.show_sql", "true")
+                .applySetting("hibernate.format_sql", "true")
+                .applySetting("hibernate.hbm2ddl.auto", "update");
+
+        Metadata metadata = new MetadataSources(srb.build())
+                // Add your entities here.
+                .addAnnotatedClass(Prima.class)
+                .addAnnotatedClass(Secunda.class)
+                .buildMetadata();
+
+        sf = metadata.buildSessionFactory();
+    }
+
+    // Add your tests, using standard JUnit.
+    @Test
+    public void hhh123Test() throws Exception {
+        EntityManager em = sf.createEntityManager();
+
+        // prepare
+        em.getTransaction().begin();
+        Long primaId;
+        {
+            Prima prim = new Prima();
+            prim.setOptionalData(null); // <-- main line
+
+            em.persist(prim);
+
+            primaId = prim.getId();
+            Assert.assertNotNull(primaId);
+        }
+        em.getTransaction().commit();
+
+        // TEST
+        em.getTransaction().begin();
+        {
+            // emulate object recieved from json
+            Prima prim = new Prima();
+            prim.setId(primaId);
+            {
+                Secunda sec = new Secunda();
+                sec.setParent(prim); // <-- not null !
+                prim.setOptionalData(sec);
+            }
+            Prima mergedPrima = em.merge(prim); // <-- exception here
+            Assert.assertNotNull(mergedPrima);
+            em.persist(mergedPrima);
+        }
+        em.getTransaction().commit();
+
+        em.close();
+
+    }
+}

--- a/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/HHH12436/Prima.java
+++ b/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/HHH12436/Prima.java
@@ -1,0 +1,43 @@
+package org.hibernate.bugs.HHH12436;
+
+import java.io.Serializable;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+/**
+ * Primari entity, owns optionalData
+ *
+ * @author localEvg
+ */
+@Entity
+public class Prima implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    //@PrimaryKeyJoinColumn
+    @OneToOne(mappedBy = "parent", optional = true , cascade = CascadeType.ALL)
+    private Secunda optionalData;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Secunda getOptionalData() {
+        return optionalData;
+    }
+
+    public void setOptionalData(Secunda optionalData) {
+        this.optionalData = optionalData;
+    }
+
+}

--- a/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/HHH12436/Secunda.java
+++ b/orm/hibernate-orm-5/src/test/java/org/hibernate/bugs/HHH12436/Secunda.java
@@ -1,0 +1,44 @@
+package org.hibernate.bugs.HHH12436;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+
+/**
+ * Secondary entity, owns by Prima, shared primary key
+ *
+ * @author localEvg
+ */
+@Entity
+public class Secunda implements Serializable {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @MapsId
+    @OneToOne(optional = false)
+    @JoinColumn(name = "id", nullable = false)
+    private Prima parent;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Prima getParent() {
+        return parent;
+    }
+
+    public void setParent(Prima parent) {
+        this.parent = parent;
+    }
+
+}


### PR DESCRIPTION
catch very unexpected exception while updgrading hibernate version 5.2.12 -> 5.2.15
in scenario when 
there are object whith null OneToOne property in database
and it is updated with object with non null OneToOne property
on new hibernate i got exception:      attempted to assign id from null one-to-one property