### PR TITLE
HV-1692 Test case to illustrate StackOverflow for custom group sequence

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -8,7 +8,7 @@
 	<name>Hibernate Validator Test Case Template</name>
 
 	<properties>
-		<version.org.hibernate.validator>6.0.12.Final</version.org.hibernate.validator>
+		<version.org.hibernate.validator>6.0.14.Final</version.org.hibernate.validator>
 		<version.javax.el>3.0.1-b09</version.javax.el>
 		<version.junit>4.12</version.junit>
 		<version.org.slf4j>1.7.22</version.org.slf4j>

--- a/validator/src/test/java/org/hibernate/validator/bugs/AnotherBean.java
+++ b/validator/src/test/java/org/hibernate/validator/bugs/AnotherBean.java
@@ -1,0 +1,19 @@
+package org.hibernate.validator.bugs;
+
+
+import org.hibernate.validator.bugs.constraints.Magic;
+
+import javax.validation.GroupSequence;
+import javax.validation.Valid;
+
+@GroupSequence({ AnotherBean.class, Magic.class})
+public class AnotherBean {
+
+    @Valid
+    private YourAnnotatedBean yourAnnotatedBean;
+
+
+    public void setYourAnnotatedBean(YourAnnotatedBean yourAnnotatedBean) {
+        this.yourAnnotatedBean = yourAnnotatedBean;
+    }
+}

--- a/validator/src/test/java/org/hibernate/validator/bugs/YourAnnotatedBean.java
+++ b/validator/src/test/java/org/hibernate/validator/bugs/YourAnnotatedBean.java
@@ -1,32 +1,17 @@
 package org.hibernate.validator.bugs;
 
-import javax.validation.constraints.NotNull;
+import org.hibernate.validator.bugs.constraints.Magic;
 
+import javax.validation.GroupSequence;
+import javax.validation.Valid;
+
+@GroupSequence({ YourAnnotatedBean.class, Magic.class})
 public class YourAnnotatedBean {
 
-	@NotNull
-	private Long id;
+	@Valid
+	private AnotherBean bean;
 
-	private String name;
-
-	protected YourAnnotatedBean() {
+	public void setBean(AnotherBean bean) {
+		this.bean = bean;
 	}
-
-	public YourAnnotatedBean(Long id, String name) {
-		this.id = id;
-		this.name = name;
-	}
-
-	public Long getId() {
-		return id;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
 }

--- a/validator/src/test/java/org/hibernate/validator/bugs/YourTestCase.java
+++ b/validator/src/test/java/org/hibernate/validator/bugs/YourTestCase.java
@@ -9,6 +9,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
+import org.hibernate.validator.testutil.DummyTraversableResolver;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -19,20 +20,28 @@ public class YourTestCase {
 
 	@BeforeClass
 	public static void setUp() {
-		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+
+		ValidatorFactory factory = Validation.byDefaultProvider()
+											 .configure()
+											 // I need caching traversable resolver
+											 .traversableResolver(new DummyTraversableResolver())
+											 .buildValidatorFactory();
+
+
 		validator = factory.getValidator();
+
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HV-NNNNN") // Please fill in the JIRA key of your issue
+	@TestForIssue(jiraKey = "HV-1692") // Please fill in the JIRA key of your issue
 	public void testYourBug() {
-		YourAnnotatedBean yourEntity1 = new YourAnnotatedBean( null, "example" );
+		YourAnnotatedBean yourEntity1 = new YourAnnotatedBean( );
+		AnotherBean anotherBean = new AnotherBean();
+		anotherBean.setYourAnnotatedBean(yourEntity1);
+		yourEntity1.setBean(anotherBean);
 
-		Set<ConstraintViolation<YourAnnotatedBean>> constraintViolations = validator.validate( yourEntity1 );
-		assertEquals( 1, constraintViolations.size() );
-		assertEquals(
-				"must not be null",
-				constraintViolations.iterator().next().getMessage() );
+		Set<ConstraintViolation<YourAnnotatedBean>> constraintViolations = validator.validate( yourEntity1);
+		assertEquals( 0, constraintViolations.size() );
 	}
 
 }

--- a/validator/src/test/java/org/hibernate/validator/bugs/constraints/Magic.java
+++ b/validator/src/test/java/org/hibernate/validator/bugs/constraints/Magic.java
@@ -1,0 +1,32 @@
+package org.hibernate.validator.bugs.constraints;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = Magic.Validator.class)
+public @interface Magic {
+
+
+
+    static class Validator implements ConstraintValidator<Magic, Object> {
+        @Override
+        public void initialize(Magic a) {
+        }
+
+        @Override
+        public boolean isValid(Object t, ConstraintValidatorContext cvc) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
It is possible to cause StackOverflow with special combination of group sequence.

This is a test case for [HV-1692](https://hibernate.atlassian.net/browse/HV-1692)

```
ava.lang.StackOverflowError
	at org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.hashOf(ConcurrentReferenceHashMap.java:265)
	at org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.get(ConcurrentReferenceHashMap.java:1111)
	at java.util.concurrent.ConcurrentMap.computeIfAbsent(ConcurrentMap.java:323)
	at org.hibernate.validator.internal.metadata.BeanMetaDataManager.getBeanMetaData(BeanMetaDataManager.java:159)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraintsForDefaultGroup(ValidatorImpl.java:440)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraintsForCurrentGroup(ValidatorImpl.java:430)

```