### PR TITLE
Exception when attempting to make a routing value required.

### DIFF
--- a/search/hibernate-search-6/orm-elasticsearch/src/test/resources/hibernate.properties
+++ b/search/hibernate-search-6/orm-elasticsearch/src/test/resources/hibernate.properties
@@ -35,3 +35,4 @@ hibernate.search.backend.log.json_pretty_printing true
 # For tests only
 hibernate.search.schema_management.strategy drop-and-create-and-drop
 hibernate.search.automatic_indexing.synchronization.strategy sync
+hibernate.search.backend.schema_management.mapping_file = index-mapping.json

--- a/search/hibernate-search-6/orm-elasticsearch/src/test/resources/index-mapping.json
+++ b/search/hibernate-search-6/orm-elasticsearch/src/test/resources/index-mapping.json
@@ -1,0 +1,5 @@
+{
+  "_routing": {
+    "required": true
+  }
+}


### PR DESCRIPTION
When attempting to specify a custom index mapping (which makes a routing value required), I'm getting the following exception:

```
com.google.gson.JsonIOException: JSON document was not fully consumed.
	at com.google.gson.Gson.assertFullConsumption(Gson.java:936) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:902) ~[gson-2.8.9.jar:?]
	at org.hibernate.search.backend.elasticsearch.impl.ElasticsearchBackendImpl.customIndexMappings(ElasticsearchBackendImpl.java:334) ~[hibernate-search-backend-elasticsearch-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.search.backend.elasticsearch.impl.ElasticsearchBackendImpl.createIndexManagerBuilder(ElasticsearchBackendImpl.java:204) ~[hibernate-search-backend-elasticsearch-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.search.engine.common.impl.IndexManagerBuildingStateHolder$BackendInitialBuildState.createIndexManagerBuildingState(IndexManagerBuildingStateHolder.java:177) ~[hibernate-search-engine-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.search.engine.common.impl.IndexManagerBuildingStateHolder.getIndexManagerBuildingState(IndexManagerBuildingStateHolder.java:84) ~[hibernate-search-engine-6.1.5.Final.jar:6.1.5.Final]
```
I believe I'm providing the correct JSON. I suspect something is wrong with the internal JSON adapters (e.g. `RoutingTypeJsonAdapter`) though I can't seem to figure it out.

@yrodiere Mind taking a quick look here and see if I'm doing something wrong or is this a bug? Thanks a bunch!
