### PR TITLE
Add disabled hibernate-enhance-maven-plugin to ORM5 and ORM6 POMs

### DIFF
--- a/orm/hibernate-orm-5/pom.xml
+++ b/orm/hibernate-orm-5/pom.xml
@@ -60,6 +60,27 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.hibernate.orm.tooling</groupId>
+				<artifactId>hibernate-enhance-maven-plugin</artifactId>
+				<version>${version.org.hibernate}</version>
+				<executions>
+					<execution>
+						<configuration>
+							<base>${project.build.testOutputDirectory}</base>
+							<dir>${project.build.testOutputDirectory}</dir>
+							<enableAssociationManagement>false</enableAssociationManagement>
+							<enableDirtyTracking>false</enableDirtyTracking>
+							<enableExtendedEnhancement>false</enableExtendedEnhancement>
+							<enableLazyInitialization>false</enableLazyInitialization>
+						</configuration>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>enhance</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -48,6 +48,27 @@
 					<target>11</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.hibernate.orm.tooling</groupId>
+				<artifactId>hibernate-enhance-maven-plugin</artifactId>
+				<version>${version.org.hibernate}</version>
+				<executions>
+					<execution>
+						<configuration>
+							<base>${project.build.testOutputDirectory}</base>
+							<dir>${project.build.testOutputDirectory}</dir>
+							<enableAssociationManagement>false</enableAssociationManagement>
+							<enableDirtyTracking>false</enableDirtyTracking>
+							<enableExtendedEnhancement>false</enableExtendedEnhancement>
+							<enableLazyInitialization>false</enableLazyInitialization>
+						</configuration>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>enhance</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
I tried to write a bug reproducer for the bytecode enhancement maven plugin and it wasn't obvious how I could make the plugin enhance my test classes. I thought it was a good idea to add a disabled version of the plugin to the ORM test-case-template POMs.

@beikov [Invited me to create a pull request](https://hibernate.zulipchat.com/#narrow/stream/132096-hibernate-user/topic/.E2.9C.94.20hibernate-enhance-maven-plugin.20reproducer/near/328470838), so here it is!