### PR TITLE
HHH-17134: Attribute::getJavaType gets incorrect class when field is annotated with @Type(io.hypersistence.utils.hibernate.type.array.ListArrayType.class)

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -35,6 +35,11 @@
 			<artifactId>junit</artifactId>
 			<version>${version.junit}</version>
 		</dependency>
+		<dependency>
+			<groupId>io.hypersistence</groupId>
+			<artifactId>hypersistence-utils-hibernate-62</artifactId>
+			<version>3.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -1,9 +1,16 @@
 package org.hibernate.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.hypersistence.utils.hibernate.type.array.ListArrayType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Id;
 import jakarta.persistence.Persistence;
-
+import java.util.List;
+import org.hibernate.annotations.Type;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,11 +35,22 @@ public class JPAUnitTestCase {
 	// Entities are auto-discovered, so just add them anywhere on class-path
 	// Add your tests, using standard JUnit.
 	@Test
-	public void hhh123Test() throws Exception {
+	public void hhh17134Test() throws Exception {
 		EntityManager entityManager = entityManagerFactory.createEntityManager();
-		entityManager.getTransaction().begin();
-		// Do stuff...
-		entityManager.getTransaction().commit();
+		var entity = entityManager.getMetamodel().managedType(Example.class);
+
+		assertEquals(List.class, entity.getAttribute("list").getJavaType());
+
 		entityManager.close();
+	}
+	
+	@Entity
+	static class Example {
+		@Id
+		private int id;
+		
+		@Column(columnDefinition = "INTEGER ARRAY")
+		@Type(ListArrayType.class)
+		private List<Integer> list;
 	}
 }


### PR DESCRIPTION
`Attribute::getJavaType` returns `Object` instead of `List`.

The test passes with Hibernate `6.2.5.Final` and fails with `6.2.6.Final` and above. I did some debugging and I belive found a commit that did the regression: https://github.com/hibernate/hibernate-orm/commit/fd661534d7189f6895507f75d12546dae6c4176d

Jira issue: https://hibernate.atlassian.net/browse/HHH-17134

P.S. I created the issue because https://github.com/vladmihalcea/hypersistence-utils maintainer suggested that this is Hibernate problem. For more context here is the issue: https://github.com/vladmihalcea/hypersistence-utils/issues/650