### PR TITLE
HCANN-132 Using record as IdClass throws NPE

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -44,8 +44,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -8,6 +8,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Objects;
+
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using the Java Persistence API.
  */
@@ -31,7 +33,9 @@ public class JPAUnitTestCase {
 	public void hhh123Test() throws Exception {
 		EntityManager entityManager = entityManagerFactory.createEntityManager();
 		entityManager.getTransaction().begin();
-		// Do stuff...
+
+		// Should pass without problem
+
 		entityManager.getTransaction().commit();
 		entityManager.close();
 	}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/BaseModel.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/BaseModel.java
@@ -1,0 +1,18 @@
+package org.hibernate.bugs.model;
+
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "accounts")
+@IdClass(BaseModelId.class)
+public class BaseModel {
+  @Id
+  private String accountName;
+
+  @Id
+  private String accountType;
+
+  private Long credit;
+}
+

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/BaseModelId.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/BaseModelId.java
@@ -1,0 +1,12 @@
+package org.hibernate.bugs.model;
+
+import java.io.Serializable;
+
+// Using a record for the IdClass
+// will save us lots of boilerplate code
+// (getters, setters, equals, hashCode, ...)
+public record BaseModelId(
+    String accountName,
+    String accountType
+) implements Serializable {
+}


### PR DESCRIPTION
In Java 17, when using a record as an IdClass, an NPE exception is thrown.

More info in the [Jira Ticket](https://hibernate.atlassian.net/browse/HCANN-132)