### PR TITLE
Test case to reproduce proxy setParameter exception

### DIFF
--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
@@ -15,65 +15,135 @@
  */
 package org.hibernate.bugs;
 
+import jakarta.persistence.*;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.annotations.Proxy;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using its built-in unit test framework.
  * Although ORMStandaloneTestCase is perfectly acceptable as a reproducer, usage of this class is much preferred.
  * Since we nearly always include a regression test with bug fixes, providing your reproducer using this method
  * simplifies the process.
- *
+ * <p>
  * What's even better?  Fork hibernate-orm itself, add your test case directly to a module's unit tests, then
  * submit it as a PR!
  */
 public class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
 
-	// Add your entities here.
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-//				Foo.class,
-//				Bar.class
-		};
-	}
+    // Add your entities here.
+    @Override
+    protected Class[] getAnnotatedClasses() {
+        return new Class[]{
+                FooImpl.class,
+                BarImpl.class
+        };
+    }
 
-	// If you use *.hbm.xml mappings, instead of annotations, add the mappings here.
-	@Override
-	protected String[] getMappings() {
-		return new String[] {
-//				"Foo.hbm.xml",
-//				"Bar.hbm.xml"
-		};
-	}
-	// If those mappings reside somewhere other than resources/org/hibernate/test, change this.
-	@Override
-	protected String getBaseForMappings() {
-		return "org/hibernate/test/";
-	}
+    @Override
+    protected String getBaseForMappings() {
+        return "org/hibernate/test/";
+    }
 
-	// Add in any settings that are specific to your test.  See resources/hibernate.properties for the defaults.
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
+    @Override
+    protected void configure(Configuration configuration) {
+        super.configure(configuration);
 
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
-		//configuration.setProperty( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
+        configuration.setProperty(AvailableSettings.SHOW_SQL, Boolean.TRUE.toString());
+        configuration.setProperty(AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString());
+    }
 
-	// Add your tests, using standard JUnit.
-	@Test
-	public void hhh123Test() throws Exception {
-		// BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
-		Session s = openSession();
-		Transaction tx = s.beginTransaction();
-		// Do stuff...
-		tx.commit();
-		s.close();
-	}
+    /**
+     * This test fails with {@link org.hibernate.query.QueryArgumentException} in setParameter() method.
+     * <pre>
+     *     org.hibernate.query.QueryArgumentException: Argument [org.hibernate.bugs.ORMUnitTestCase$FooImpl@f2fec8]
+     *     of type [org.hibernate.bugs.ORMUnitTestCase$FooImpl$HibernateProxy$ACmq807n] did not match parameter
+     *     type [org.hibernate.bugs.ORMUnitTestCase$FooImpl (n/a)]
+     * </pre>
+     */
+    @Test
+    public void ProxyAsQueryParameterTest() {
+        Session s = openSession();
+        Transaction tx = s.beginTransaction();
+
+        BarImpl bar = new BarImpl();
+        FooImpl foo = new FooImpl();
+        bar.setFoo(foo);
+        s.persist(bar);
+
+        Long id = foo.getId();
+
+        session.flush();
+        session.clear();
+
+        Foo fooProxy = session.getReference(Foo.class, id);
+
+        Bar loadedBar = (Bar) session.createQuery("SELECT b FROM Bar b WHERE b.foo = ?1")
+                // replacing with Hibernate.unproxy(fooProxy) works, but we don't want to initialize the proxy
+                .setParameter(1, fooProxy)
+                .getSingleResult();
+
+        assertNotNull(loadedBar);
+
+        tx.commit();
+        s.close();
+    }
+
+    public interface Bar extends Foo {
+    }
+
+    public interface Foo {
+    }
+
+    @Entity(name = "Foo")
+    @Proxy(proxyClass = Foo.class)
+    public static class FooImpl implements Foo {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Entity(name = "Bar")
+    @Proxy(proxyClass = Bar.class)
+    public static class BarImpl implements Bar {
+
+        @ManyToOne(fetch = FetchType.LAZY, targetEntity = FooImpl.class, cascade = CascadeType.ALL)
+        @JoinColumn(name = "FOO_ID")
+        private Foo foo;
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public void setFoo(Foo foo) {
+            this.foo = foo;
+        }
+    }
 }

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
@@ -68,7 +68,7 @@ public class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
      * </pre>
      */
     @Test
-    public void ProxyAsQueryParameterTest() {
+    public void proxyAsQueryParameterTest() {
         Session s = openSession();
         Transaction tx = s.beginTransaction();
 
@@ -84,7 +84,7 @@ public class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
 
         Foo fooProxy = session.getReference(Foo.class, id);
 
-        Bar loadedBar = (Bar) session.createQuery("SELECT b FROM Bar b WHERE b.foo = ?1")
+        Bar loadedBar = session.createQuery("SELECT b FROM Bar b WHERE b.foo = ?1", Bar.class)
                 // replacing with Hibernate.unproxy(fooProxy) works, but we don't want to initialize the proxy
                 .setParameter(1, fooProxy)
                 .getSingleResult();


### PR DESCRIPTION
See test `org.hibernate.bugs.ORMUnitTestCase#proxyAsQueryParameterTest` throws 

```
org.hibernate.query.QueryArgumentException: Argument [org.hibernate.bugs.ORMUnitTestCase$FooImpl@3de7f92a] of type [org.hibernate.bugs.ORMUnitTestCase$FooImpl$HibernateProxy$51iSYkKS] did not match parameter type [org.hibernate.bugs.ORMUnitTestCase$FooImpl (n/a)]

	at org.hibernate.query.spi.QueryParameterBindingValidator.validate(QueryParameterBindingValidator.java:85)
	at org.hibernate.query.spi.QueryParameterBindingValidator.validate(QueryParameterBindingValidator.java:32)
	at org.hibernate.query.internal.QueryParameterBindingImpl.validate(QueryParameterBindingImpl.java:362)
	at org.hibernate.query.internal.QueryParameterBindingImpl.setBindValue(QueryParameterBindingImpl.java:137)
	at org.hibernate.query.spi.AbstractCommonQueryContract.setParameter(AbstractCommonQueryContract.java:926)
	at org.hibernate.query.spi.AbstractSelectionQuery.setParameter(AbstractSelectionQuery.java:924)
	at org.hibernate.query.sqm.internal.QuerySqmImpl.setParameter(QuerySqmImpl.java:1282)
	at org.hibernate.query.sqm.internal.QuerySqmImpl.setParameter(QuerySqmImpl.java:140)
	at org.hibernate.bugs.ORMUnitTestCase.proxyAsQueryParameterTest(ORMUnitTestCase.java:89)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.hibernate.testing.junit4.ExtendedFrameworkMethod.invokeExplosively(ExtendedFrameworkMethod.java:45)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.Thread.run(Thread.java:1583)
