### PR TITLE
Test that simple entities don't create HTE_ tables in Oracle

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -35,6 +35,16 @@
 			<artifactId>junit</artifactId>
 			<version>${version.junit}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>oracle-xe</artifactId>
+			<version>1.19.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+			<version>21.8.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
I would expect that simple entities in Oracle would not create HTE_* tables, but they do.