### PR TITLE
Embeddable annotation throws Dialect does not support AggregateSupportImpl exception on mysql 

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -35,6 +35,16 @@
 			<artifactId>junit</artifactId>
 			<version>${version.junit}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>8.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.16.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -3,7 +3,6 @@ package org.hibernate.bugs;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
@@ -1,11 +1,19 @@
 package org.hibernate.bugs;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.bugs.domain.UserEntity;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.type.format.jackson.JacksonJsonFormatMapper;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Properties;
 
 /**
  * This template demonstrates how to develop a standalone test case for Hibernate ORM.  Although this is perfectly
@@ -17,15 +25,23 @@ public class ORMStandaloneTestCase {
 
 	@Before
 	public void setup() {
-		StandardServiceRegistryBuilder srb = new StandardServiceRegistryBuilder()
-			// Add in any settings that are specific to your test. See resources/hibernate.properties for the defaults.
-			.applySetting( "hibernate.show_sql", "true" )
-			.applySetting( "hibernate.format_sql", "true" )
-			.applySetting( "hibernate.hbm2ddl.auto", "update" );
+		Properties props = new Properties();
+		props.put("hibernate.show_sql", "true");
+		props.put("hibernate.format_sql", "true");
+		props.put("hibernate.highlight_sql", "true");
+		props.put("hibernate.hbm2ddl.auto", "create-drop");
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		props.put(AvailableSettings.JSON_FORMAT_MAPPER, new JacksonJsonFormatMapper(objectMapper));
 
-		Metadata metadata = new MetadataSources( srb.build() )
+		final StandardServiceRegistry srb =
+			new StandardServiceRegistryBuilder()
+				.applySettings(props)
+				.build();
+
+		Metadata metadata = new MetadataSources( srb )
 		// Add your entities here.
-		//	.addAnnotatedClass( Foo.class )
+			.addAnnotatedClass( UserEntity.class )
 			.buildMetadata();
 
 		sf = metadata.buildSessionFactory();

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
@@ -15,8 +15,6 @@
  */
 package org.hibernate.bugs;
 
-import java.util.Locale;
-
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.AvailableSettings;
@@ -25,11 +23,12 @@ import org.hibernate.id.SequenceMismatchStrategy;
 import org.hibernate.id.enhanced.StandardOptimizerDescriptor;
 import org.hibernate.loader.BatchFetchStyle;
 import org.hibernate.query.NullPrecedence;
-
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Locale;
 
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using its built-in unit test framework.

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/AIRuleDefinition.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/AIRuleDefinition.java
@@ -1,0 +1,30 @@
+package org.hibernate.bugs.domain;
+
+import java.util.UUID;
+
+public class AIRuleDefinition extends RuleDefinition {
+
+	private UUID ruleDefinitionId;
+	private String ruleName;
+
+	public UUID getRuleDefinitionId() {
+		return ruleDefinitionId;
+	}
+
+	public void setRuleDefinitionId(UUID ruleDefinitionId) {
+		this.ruleDefinitionId = ruleDefinitionId;
+	}
+
+	public String getRuleName() {
+		return ruleName;
+	}
+
+	public void setRuleName(String ruleName) {
+		this.ruleName = ruleName;
+	}
+
+	@Override
+	public String getRuleType() {
+		return "AI";
+	}
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/RuleDefinition.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/RuleDefinition.java
@@ -1,0 +1,17 @@
+package org.hibernate.bugs.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "clazz")
+@JsonSubTypes({
+	@JsonSubTypes.Type(value = AIRuleDefinition.class, name = "AI_RULE")
+})
+public abstract class RuleDefinition {
+	@JsonIgnore
+	public abstract String getRuleType();
+	public abstract void setRuleName(String name);
+
+	public abstract String getRuleName();
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/UserEntity.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/UserEntity.java
@@ -1,0 +1,17 @@
+package org.hibernate.bugs.domain;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+public class UserEntity {
+
+	@Id private UUID userId;
+	@JdbcTypeCode(SqlTypes.JSON)
+	private UserSettings rules;
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/UserSettings.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/UserSettings.java
@@ -1,0 +1,18 @@
+package org.hibernate.bugs.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Embeddable
+public class UserSettings extends LinkedHashSet<RuleDefinition> {
+
+	public UserSettings() {
+	}
+
+	public UserSettings(Set<RuleDefinition> ruleDefinitions) {
+		super.addAll(ruleDefinitions);
+	}
+
+}

--- a/orm/hibernate-orm-6/src/test/resources/META-INF/persistence.xml
+++ b/orm/hibernate-orm-6/src/test/resources/META-INF/persistence.xml
@@ -13,10 +13,10 @@
         <properties>
             <property name="hibernate.archive.autodetection" value="class, hbm"/>
 
-            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
-            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
-            <property name="hibernate.connection.username" value="sa"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect"/>
+            <property name="hibernate.connection.driver_class" value="com.mysql.cj.jdbc.Driver"/>
+            <property name="hibernate.connection.url" value="jdbc:mysql://localhost:3306/testdb"/>
+            <property name="hibernate.connection.username" value="root"/>
 
             <property name="hibernate.connection.pool_size" value="5"/>
 

--- a/orm/hibernate-orm-6/src/test/resources/hibernate.properties
+++ b/orm/hibernate-orm-6/src/test/resources/hibernate.properties
@@ -5,11 +5,11 @@
 # See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 #
 
-hibernate.dialect org.hibernate.dialect.H2Dialect
-hibernate.connection.driver_class org.h2.Driver
+hibernate.dialect org.hibernate.dialect.MySQLDialect
+hibernate.connection.driver_class com.mysql.cj.jdbc.Driver
 #hibernate.connection.url jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE
-hibernate.connection.url jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1
-hibernate.connection.username sa
+hibernate.connection.url jdbc:mysql://localhost:3306/testdb
+hibernate.connection.username root
 hibernate.connection.password 
 
 hibernate.connection.pool_size 5


### PR DESCRIPTION
Putting `Embeddable` annotation on `UserSettings.java` throws an exception : 

```
java.lang.UnsupportedOperationException: Dialect does not support requiresAggregateCustomWriteExpressionRenderer: org.hibernate.dialect.aggregate.AggregateSupportImpl
````

Due to not having _AggregateSupportImpl_ for Mysql. 

To reproduce the error run `ORMStandaloneTestCase.java`