### PR TITLE
Update dependabot rules for the Hibernate group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,7 @@ updates:
           - "com.h2database:*"
           - "org.assertj:*"
     ignore:
+      - dependency-name: "org.hibernate.orm.tooling:hibernate-enhance-maven-plugin"
       - dependency-name: "org.hibernate:hibernate-core"
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "org.hibernate*"

--- a/envers/envers-6/pom.xml
+++ b/envers/envers-6/pom.xml
@@ -10,19 +10,29 @@
     <properties>
         <version.com.h2database>2.2.224</version.com.h2database>
         <version.junit>4.13.2</version.junit>
-        <version.org.hibernate>6.4.4.Final</version.org.hibernate>
+        <version.org.hibernate.orm>6.4.4.Final</version.org.hibernate.orm>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-platform</artifactId>
+                <version>${version.org.hibernate.orm}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-envers</artifactId>
-            <version>${version.org.hibernate}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-testing</artifactId>
-            <version>${version.org.hibernate}</version>
         </dependency>
 
         <dependency>

--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -10,19 +10,29 @@
 	<properties>
 		<version.com.h2database>2.2.224</version.com.h2database>
 		<version.junit>4.13.2</version.junit>
-		<version.org.hibernate>6.4.4.Final</version.org.hibernate>
+		<version.org.hibernate.orm>6.4.4.Final</version.org.hibernate.orm>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.hibernate.orm</groupId>
+				<artifactId>hibernate-platform</artifactId>
+				<version>${version.org.hibernate.orm}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-core</artifactId>
-			<version>${version.org.hibernate}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-testing</artifactId>
-			<version>${version.org.hibernate}</version>
 		</dependency>
 
 		<dependency>
@@ -51,7 +61,7 @@
 			<plugin>
 				<groupId>org.hibernate.orm.tooling</groupId>
 				<artifactId>hibernate-enhance-maven-plugin</artifactId>
-				<version>${version.org.hibernate}</version>
+				<version>${version.org.hibernate.orm}</version>
 				<executions>
 					<execution>
 						<configuration>


### PR DESCRIPTION
Use `hibernate-platform` for ORM updates to not confuse Dependabot in the ORM 5 module (it tries to update the enhance plugin to the latest there)