### PR TITLE
HHH-18291 Reproducer

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<version.com.h2database>2.2.224</version.com.h2database>
 		<version.junit>4.13.2</version.junit>
-		<version.org.hibernate.orm>6.5.2.Final</version.org.hibernate.orm>
+		<version.org.hibernate.orm>6.4.8.Final</version.org.hibernate.orm>
 	</properties>
 
 	<dependencyManagement>
@@ -54,8 +54,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>16</source>
+					<target>16</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/InvoiceBE.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/InvoiceBE.java
@@ -1,0 +1,30 @@
+package org.hibernate.bugs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.TenantId;
+
+@Entity
+@Table(name = "invoice")
+public class InvoiceBE {
+
+  @Id
+  @GeneratedValue
+  private long id;
+
+  @Column(name = "removed", nullable = false)
+  private boolean removed;
+
+  public InvoiceBE setId(long id) {
+    this.id = id;
+    return this;
+  }
+
+  public InvoiceBE setRemoved(boolean removed) {
+    this.removed = removed;
+    return this;
+  }
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -1,9 +1,18 @@
 package org.hibernate.bugs;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Persistence;
 
+import jakarta.persistence.TypedQuery;
+import java.util.List;
+import org.hibernate.annotations.TenantId;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,11 +37,26 @@ public class JPAUnitTestCase {
 	// Entities are auto-discovered, so just add them anywhere on class-path
 	// Add your tests, using standard JUnit.
 	@Test
-	public void hhh123Test() throws Exception {
-		EntityManager entityManager = entityManagerFactory.createEntityManager();
-		entityManager.getTransaction().begin();
-		// Do stuff...
-		entityManager.getTransaction().commit();
-		entityManager.close();
-	}
+	public void hhh18291Test() throws Exception {
+    EntityManager entityManager = entityManagerFactory.createEntityManager();
+    entityManager.getTransaction().begin();
+
+    InvoiceBE invoice = entityManager.merge(new InvoiceBE().setId(1L).setRemoved(false));
+    PaidInvoiceBE paidInvoice = entityManager.merge(new PaidInvoiceBE().setId(1).setInvoice(invoice));
+
+    TypedQuery<Boolean> query = entityManager.createQuery("""
+        SELECT i.removed = false
+          AND (SELECT count(*) = 0
+                FROM PaidInvoiceBE pi
+                WHERE pi.invoice.id = i.id)
+        FROM InvoiceBE i
+        WHERE i.id = :invoiceId
+        """, Boolean.class);
+    query.setParameter("invoiceId", 1L);
+    Boolean result = query.getSingleResult();
+    System.out.println(result);
+
+    entityManager.getTransaction().commit();
+    entityManager.close();
+  }
 }

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/PaidInvoiceBE.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/PaidInvoiceBE.java
@@ -1,0 +1,33 @@
+package org.hibernate.bugs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.TenantId;
+
+@Entity
+@Table(
+    name = "paid_invoice")
+public class PaidInvoiceBE {
+
+  @Id
+  @GeneratedValue
+  private long id;
+
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  private InvoiceBE invoice;
+
+  public PaidInvoiceBE setId(long id) {
+    this.id = id;
+    return this;
+  }
+
+  public PaidInvoiceBE setInvoice(InvoiceBE invoice) {
+    this.invoice = invoice;
+    return this;
+  }
+}


### PR DESCRIPTION
```
Caused by: org.hibernate.query.SemanticException: Non-boolean expression used in predicate context: (SELECTcount(*)=0FROMPaidInvoiceBEpiWHEREpi.invoice.id=i.id)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitBooleanExpressionPredicate(SemanticQueryBuilder.java:2685)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitBooleanExpressionPredicate(SemanticQueryBuilder.java:269)
	at org.hibernate.grammars.hql.HqlParser$BooleanExpressionPredicateContext.accept(HqlParser.java:6232)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitAndPredicate(SemanticQueryBuilder.java:2262)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitAndPredicate(SemanticQueryBuilder.java:269)
	at org.hibernate.grammars.hql.HqlParser$AndPredicateContext.accept(HqlParser.java:6040)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visitChildren(AbstractParseTreeVisitor.java:46)
	at org.hibernate.grammars.hql.HqlParserBaseVisitor.visitExpressionOrPredicate(HqlParserBaseVisitor.java:896)
	at org.hibernate.grammars.hql.HqlParser$ExpressionOrPredicateContext.accept(HqlParser.java:7928)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSelectableNode(SemanticQueryBuilder.java:1332)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSelection(SemanticQueryBuilder.java:1309)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSelectClause(SemanticQueryBuilder.java:1302)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuery(SemanticQueryBuilder.java:1154)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuerySpecExpression(SemanticQueryBuilder.java:941)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuerySpecExpression(SemanticQueryBuilder.java:269)
	at org.hibernate.grammars.hql.HqlParser$QuerySpecExpressionContext.accept(HqlParser.java:1869)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSimpleQueryGroup(SemanticQueryBuilder.java:926)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSimpleQueryGroup(SemanticQueryBuilder.java:269)
	at org.hibernate.grammars.hql.HqlParser$SimpleQueryGroupContext.accept(HqlParser.java:1740)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSelectStatement(SemanticQueryBuilder.java:443)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitStatement(SemanticQueryBuilder.java:402)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.buildSemanticModel(SemanticQueryBuilder.java:311)
	at org.hibernate.query.hql.internal.StandardHqlTranslator.translate(StandardHqlTranslator.java:71)
	at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.createHqlInterpretation(QueryInterpretationCacheStandardImpl.java:165)
	at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.resolveHqlInterpretation(QueryInterpretationCacheStandardImpl.java:147)
	at org.hibernate.internal.AbstractSharedSessionContract.interpretHql(AbstractSharedSessionContract.java:790)
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:840)
	... 29 more
```