### PR TITLE
Bug reproduction - java.lang.AssertionError

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<version.com.h2database>2.3.230</version.com.h2database>
 		<version.junit>4.13.2</version.junit>
-		<version.org.hibernate.orm>6.5.2.Final</version.org.hibernate.orm>
+		<version.org.hibernate.orm>6.6.0.CR1</version.org.hibernate.orm>
 	</properties>
 
 	<dependencyManagement>
@@ -54,8 +54,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ToOneJoinFetchTest.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ToOneJoinFetchTest.java
@@ -1,0 +1,47 @@
+package org.hibernate.bugs;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ToOneJoinFetchTest {
+
+    private EntityManagerFactory entityManagerFactory;
+
+    @Before
+    public void init() {
+        entityManagerFactory = Persistence.createEntityManagerFactory("templatePU");
+    }
+
+    @After
+    public void destroy() {
+        entityManagerFactory.close();
+    }
+
+    @Test
+    public void testToOneAttributeJoinFetch() throws Exception {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        entityManager.getTransaction().begin();
+
+        //language=HQL
+        var hql = """
+                	SELECT a_entity FROM org.hibernate.entities.AEntity a_entity
+                	LEFT JOIN FETCH a_entity.b_entity b_entity
+                	LEFT JOIN FETCH b_entity.c_entities c_entities
+                """;
+
+        var query = entityManager.createQuery(hql, List.class);
+        var res = query.getResultList();
+
+        assertEquals(0, res.size());
+        entityManager.getTransaction().commit();
+        entityManager.close();
+    }
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/AEntity.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/AEntity.java
@@ -1,0 +1,23 @@
+package org.hibernate.entities;
+
+import jakarta.persistence.*;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name = "a_entities")
+public class AEntity {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "b_entity_id", updatable = false, insertable = false)
+    private B2Entity b_entity; // default customer => owner
+
+    @Column(name = "b_entity_id")
+    private Long b_entity_id;
+
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/B1Entity.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/B1Entity.java
@@ -1,0 +1,9 @@
+package org.hibernate.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "b_entities")
+public class B1Entity extends BaseBEntity {
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/B2Entity.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/B2Entity.java
@@ -1,0 +1,9 @@
+package org.hibernate.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "b_entities")
+public class B2Entity extends BaseBEntity {
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/BaseBEntity.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/BaseBEntity.java
@@ -1,0 +1,24 @@
+package org.hibernate.entities;
+
+import jakarta.persistence.*;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+/**
+ * Common customer items useful in all contexts where a customer is used.
+ */
+@MappedSuperclass
+public class BaseBEntity {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "b_entity")
+    private Set<CEntity> c_entities = new LinkedHashSet<>();
+
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/CEntity.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/entities/CEntity.java
@@ -1,0 +1,23 @@
+package org.hibernate.entities;
+
+import jakarta.persistence.*;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name = "c_entities")
+public class CEntity {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(name = "b_id")
+    private Long bEntityId;
+
+    @ManyToOne
+    @JoinColumn(name = "b_id", updatable = false, insertable = false)
+    private B1Entity b_entity;
+
+}


### PR DESCRIPTION
## Description

When migrating to fresh hibernate, some of our queries stopped working, resulting in the following stack trace:
```
java.lang.AssertionError
	at org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping.createTableGroupJoin(ToOneAttributeMapping.java:1985)
	at org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping.createTableGroupForDelayedFetch(ToOneAttributeMapping.java:1806)
	at org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping.createCircularBiDirectionalFetch(ToOneAttributeMapping.java:1345)
	at org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping.resolveCircularFetch(ToOneAttributeMapping.java:1024)
[...]
```

The issue is not resolved by [HHH-18086](https://hibernate.atlassian.net/browse/HHH-18086), which I tested by a fresh [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/org/hibernate/orm/hibernate-core/6.6.0-SNAPSHOT/) version of the library. 

## Bug description

I found out the issue in the Hibernate's fetch builder logic. 
* In case of having the following entities: A, B1, B2, C, where B1, and B2 refer to the same table.
* Also, having a mapping A.b, and C.b, and the following SQL:
```
Select a from A a
LEFT JOIN FETCH a.b b
LEFT JOIN FETCH b.c c
```
* The issue occurs. This can be fixed by renaming the mapping, for example from: A.b to A.b1

## Work a round
Changing entity's A field `b` name to any name that differs from entity's C field `b`. It works both ways - changing entity's C field `b` name also works. 