### PR TITLE
Convert ORM 6 test templates to use JUnit 5

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -9,8 +9,9 @@
 
 	<properties>
 		<version.com.h2database>2.3.230</version.com.h2database>
-		<version.junit>4.13.2</version.junit>
+		<version.junit-jupiter>5.10.3</version.junit-jupiter>
 		<version.org.hibernate.orm>6.6.0.Final</version.org.hibernate.orm>
+		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
 	</properties>
 
 	<dependencyManagement>
@@ -19,6 +20,13 @@
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-platform</artifactId>
 				<version>${version.org.hibernate.orm}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${version.junit-jupiter}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -41,9 +49,21 @@
 			<version>${version.com.h2database}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${version.junit}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${version.org.assertj.assertj-core}</version>
 		</dependency>
 	</dependencies>
 

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -1,34 +1,34 @@
 package org.hibernate.bugs;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using the Java Persistence API.
  */
-public class JPAUnitTestCase {
+class JPAUnitTestCase {
 
 	private EntityManagerFactory entityManagerFactory;
 
-	@Before
-	public void init() {
+	@BeforeEach
+	void init() {
 		entityManagerFactory = Persistence.createEntityManagerFactory( "templatePU" );
 	}
 
-	@After
-	public void destroy() {
+	@AfterEach
+	void destroy() {
 		entityManagerFactory.close();
 	}
 
 	// Entities are auto-discovered, so just add them anywhere on class-path
 	// Add your tests, using standard JUnit.
 	@Test
-	public void hhh123Test() throws Exception {
+	void hhh123Test() throws Exception {
 		EntityManager entityManager = entityManagerFactory.createEntityManager();
 		entityManager.getTransaction().begin();
 		// Do stuff...

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
@@ -4,37 +4,37 @@ import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This template demonstrates how to develop a standalone test case for Hibernate ORM.  Although this is perfectly
  * acceptable as a reproducer, usage of ORMUnitTestCase is preferred!
  */
-public class ORMStandaloneTestCase {
+class ORMStandaloneTestCase {
 
 	private SessionFactory sf;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		StandardServiceRegistryBuilder srb = new StandardServiceRegistryBuilder()
-			// Add in any settings that are specific to your test. See resources/hibernate.properties for the defaults.
-			.applySetting( "hibernate.show_sql", "true" )
-			.applySetting( "hibernate.format_sql", "true" )
-			.applySetting( "hibernate.hbm2ddl.auto", "update" );
+				// Add in any settings that are specific to your test. See resources/hibernate.properties for the defaults.
+				.applySetting( "hibernate.show_sql", "true" )
+				.applySetting( "hibernate.format_sql", "true" )
+				.applySetting( "hibernate.hbm2ddl.auto", "update" );
 
 		Metadata metadata = new MetadataSources( srb.build() )
-		// Add your entities here.
-		//	.addAnnotatedClass( Foo.class )
-			.buildMetadata();
+				// Add your entities here.
+				//	.addAnnotatedClass( Foo.class )
+				.buildMetadata();
 
 		sf = metadata.buildSessionFactory();
 	}
 
-	// Add your tests, using standard JUnit.
-
+	// Add your tests, using standard JUnit 5:
 	@Test
-	public void hhh123Test() throws Exception {
+	void hhh123Test() throws Exception {
 
 	}
 }

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
@@ -15,65 +15,56 @@
  */
 package org.hibernate.bugs;
 
-import org.hibernate.Session;
-import org.hibernate.Transaction;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using its built-in unit test framework.
  * Although ORMStandaloneTestCase is perfectly acceptable as a reproducer, usage of this class is much preferred.
  * Since we nearly always include a regression test with bug fixes, providing your reproducer using this method
  * simplifies the process.
- *
+ * <p>
  * What's even better?  Fork hibernate-orm itself, add your test case directly to a module's unit tests, then
  * submit it as a PR!
  */
-public class ORMUnitTestCase extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				// Add your entities here.
+				// Foo.class,
+				// Bar.class
+		},
+		// If you use *.hbm.xml mappings, instead of annotations, add the mappings here.
+		xmlMappings = {
+				// "org/hibernate/test/Foo.hbm.xml",
+				// "org/hibernate/test/Bar.hbm.xml"
+		}
+)
+@ServiceRegistry(
+		// Add in any settings that are specific to your test.  See resources/hibernate.properties for the defaults.
+		settings = {
+				// For your own convenience to see generated queries:
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true"),
+				// @Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
 
-	// Add your entities here.
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-//				Foo.class,
-//				Bar.class
-		};
-	}
+				// Add your own settings that are a part of your quarkus configuration:
+				// @Setting( name = AvailableSettings.SOME_CONFIGURATION_PROPERTY, value = "SOME_VALUE" ),
+		}
+)
+@SessionFactory
+class ORMUnitTestCase {
 
-	// If you use *.hbm.xml mappings, instead of annotations, add the mappings here.
-	@Override
-	protected String[] getMappings() {
-		return new String[] {
-//				"Foo.hbm.xml",
-//				"Bar.hbm.xml"
-		};
-	}
-	// If those mappings reside somewhere other than resources/org/hibernate/test, change this.
-	@Override
-	protected String getBaseForMappings() {
-		return "org/hibernate/test/";
-	}
-
-	// Add in any settings that are specific to your test.  See resources/hibernate.properties for the defaults.
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
-		//configuration.setProperty( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	// Add your tests, using standard JUnit.
+	// Add your tests, using standard JUnit 5.
 	@Test
-	public void hhh123Test() throws Exception {
-		// BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
-		Session s = openSession();
-		Transaction tx = s.beginTransaction();
-		// Do stuff...
-		tx.commit();
-		s.close();
+	void hhh123Test(SessionFactoryScope scope) throws Exception {
+		scope.inTransaction( session -> {
+			// Do stuff...
+		} );
 	}
 }

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
@@ -15,21 +15,15 @@
  */
 package org.hibernate.bugs;
 
-import java.util.Locale;
-
-import org.hibernate.Session;
-import org.hibernate.Transaction;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.id.SequenceMismatchStrategy;
-import org.hibernate.id.enhanced.StandardOptimizerDescriptor;
-import org.hibernate.loader.BatchFetchStyle;
-import org.hibernate.query.NullPrecedence;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using its built-in unit test framework.
@@ -37,49 +31,43 @@ import org.junit.runner.RunWith;
  * What's even better?  Fork hibernate-orm itself, add your test case directly to a module's unit tests, then
  * submit it as a PR!
  */
-@RunWith(BytecodeEnhancerRunner.class) // This runner enables bytecode enhancement for your test.
-public class QuarkusLikeORMUnitTestCase extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				// Add your entities here, e.g.:
+				// Foo.class,
+				// Bar.class
+		}
+)
+@ServiceRegistry(
+		// Add in any settings that are specific to your test.  See resources/hibernate.properties for the defaults.
+		settings = {
+				// For your own convenience to see generated queries:
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true"),
+				// @Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
 
-	// Add your entities here.
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-//				Foo.class,
-//				Bar.class
-		};
-	}
+				// Other settings that will make your test case run under similar configuration that Quarkus is using by default:
+				@Setting(name = AvailableSettings.PREFERRED_POOLED_OPTIMIZER, value = "pooled-lo"),
+				@Setting(name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "16"),
+				@Setting(name = AvailableSettings.BATCH_FETCH_STYLE, value = "PADDED"),
+				@Setting(name = AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, value = "2048"),
+				@Setting(name = AvailableSettings.DEFAULT_NULL_ORDERING, value = "none"),
+				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true"),
+				@Setting(name = AvailableSettings.SEQUENCE_INCREMENT_SIZE_MISMATCH_STRATEGY, value = "none"),
 
-	// Add in any settings that are specific to your test.  See resources/hibernate.properties for the defaults.
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		// For your own convenience to see generated queries:
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
-		//configuration.setProperty( AvailableSettings.GENERATE_STATISTICS, "true" );
-
-		// Other settings that will make your test case run under similar configuration that Quarkus is using by default:
-		configuration.setProperty( AvailableSettings.PREFERRED_POOLED_OPTIMIZER, StandardOptimizerDescriptor.POOLED_LO.getExternalName() );
-		configuration.setProperty( AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, "16" );
-		configuration.setProperty( AvailableSettings.BATCH_FETCH_STYLE, BatchFetchStyle.PADDED.toString() );
-		configuration.setProperty( AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, "2048" );
-		configuration.setProperty( AvailableSettings.DEFAULT_NULL_ORDERING, NullPrecedence.NONE.toString().toLowerCase( Locale.ROOT) );
-		configuration.setProperty( AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, "true" );
-		configuration.setProperty( AvailableSettings.SEQUENCE_INCREMENT_SIZE_MISMATCH_STRATEGY, SequenceMismatchStrategy.NONE.toString() );
-
-		// Add your own settings that are a part of your quarkus configuration:
-		// configuration.setProperty( AvailableSettings.SOME_CONFIGURATION_PROPERTY, "SOME_VALUE" );
-	}
+				// Add your own settings that are a part of your quarkus configuration:
+				// @Setting( name = AvailableSettings.SOME_CONFIGURATION_PROPERTY, value = "SOME_VALUE" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+class QuarkusLikeORMUnitTestCase {
 
 	// Add your tests, using standard JUnit.
 	@Test
-	public void hhh123Test() throws Exception {
-		// BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
-		Session s = openSession();
-		Transaction tx = s.beginTransaction();
-		// Do stuff...
-		tx.commit();
-		s.close();
+	void hhh123Test(SessionFactoryScope scope) throws Exception {
+		scope.inTransaction( session -> {
+			// Do stuff...
+		} );
 	}
 }


### PR DESCRIPTION
fixes https://github.com/hibernate/hibernate-test-case-templates/issues/417

I think it's a good time to switch to JUnit 5 templates for ORM 6 since we have the bytecode-enhanced tests running with JUnit 5 too now