### PR TITLE
NPE selecting embedded fields from union query wrapped in criteria query

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -11,7 +11,7 @@
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
 		<version.org.hibernate.orm>6.6.4.Final</version.org.hibernate.orm>
-		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
+		<version.org.assertj.assertj-core>3.27.0</version.org.assertj.assertj-core>
 	</properties>
 
 	<dependencyManagement>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -1,5 +1,9 @@
 package org.hibernate.bugs;
 
+import jakarta.persistence.Tuple;
+import org.hibernate.Session;
+import org.hibernate.bugs.model.Person;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -7,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
+
+import java.util.List;
 
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using the Java Persistence API.
@@ -32,6 +38,44 @@ class JPAUnitTestCase {
 		EntityManager entityManager = entityManagerFactory.createEntityManager();
 		entityManager.getTransaction().begin();
 		// Do stuff...
+
+		final HibernateCriteriaBuilder cb = entityManager.unwrap(Session.class).getCriteriaBuilder();
+		var wrapperQuery = cb.createTupleQuery();
+		var subquery1 = wrapperQuery.subquery(Tuple.class);
+		var root1 = subquery1.from(Person.class);
+		subquery1.multiselect(
+						root1.get("id").alias("id"),
+						root1.get("firstName").alias("firstName"),
+						root1.get("lastName").alias("lastName"),
+						root1.get("email").alias("email"),
+						root1.get("phone").alias("phone"),
+						root1.get("address").alias("address"))
+				.where(cb.equal(root1.get("address").get("city"), "NYC"));
+
+		var subquery2 = wrapperQuery.subquery(Tuple.class);
+		var root2 = subquery2.from(Person.class);
+		subquery2.multiselect(
+						root2.get("id").alias("id"),
+						root2.get("firstName").alias("firstName"),
+						root2.get("lastName").alias("lastName"),
+						root2.get("email").alias("email"),
+						root2.get("phone").alias("phone"),
+						root2.get("address").alias("address"))
+				.where(cb.like(root2.get("lastName"), "ba%"));
+
+		var unionQuery = cb.union(subquery1, subquery2);
+		var wrapperRoot = wrapperQuery.from(unionQuery);
+
+		wrapperQuery.multiselect(
+				wrapperRoot.get("id").alias("id"),
+				wrapperRoot.get("email").alias("email"),
+				wrapperRoot.get("address").alias("address")
+		).orderBy(cb.desc(cb.literal(1)));
+
+		List<Tuple> tuples = entityManager.createQuery(wrapperQuery).setMaxResults(5).getResultList();
+
+		System.out.println(tuples);
+
 		entityManager.getTransaction().commit();
 		entityManager.close();
 	}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Address.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Address.java
@@ -1,0 +1,46 @@
+package org.hibernate.bugs.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Address {
+
+  @Column(name = "address_line1")
+  private String addressLine1;
+
+  @Column(name = "city")
+  private String city;
+
+  @Column(name = "state")
+  private String state;
+
+  @Column(name = "zip")
+  private String zip;
+
+  public Address() {
+  }
+
+  public Address(String addressLine1, String city, String state, String zip) {
+    this.addressLine1 = addressLine1;
+    this.city = city;
+    this.state = state;
+    this.zip = zip;
+  }
+
+  public String getAddressLine1() {
+    return addressLine1;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public String getZip() {
+    return zip;
+  }
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Person.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Person.java
@@ -1,0 +1,78 @@
+package org.hibernate.bugs.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "person")
+public class Person {
+  @Id
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "first_name")
+  private String firstName;
+
+  @Column(name = "last_name")
+  private String lastName;
+
+  @Column(name = "email")
+  private String email;
+
+  @Column(name = "phone")
+  private String phone;
+
+  @Embedded
+  private Address address;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
+
+  public void setPhone(String phone) {
+    this.phone = phone;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    address = address;
+  }
+}

--- a/search/hibernate-search-5/elasticsearch-5/pom.xml
+++ b/search/hibernate-search-5/elasticsearch-5/pom.xml
@@ -13,7 +13,7 @@
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
-		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
+		<version.org.assertj.assertj-core>3.27.0</version.org.assertj.assertj-core>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/search/hibernate-search-5/lucene/pom.xml
+++ b/search/hibernate-search-5/lucene/pom.xml
@@ -13,7 +13,7 @@
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
-		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
+		<version.org.assertj.assertj-core>3.27.0</version.org.assertj.assertj-core>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/search/hibernate-search-6/orm-elasticsearch/pom.xml
+++ b/search/hibernate-search-6/orm-elasticsearch/pom.xml
@@ -13,7 +13,7 @@
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
-		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
+		<version.org.assertj.assertj-core>3.27.0</version.org.assertj.assertj-core>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/search/hibernate-search-6/orm-lucene/pom.xml
+++ b/search/hibernate-search-6/orm-lucene/pom.xml
@@ -13,7 +13,7 @@
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
-		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
+		<version.org.assertj.assertj-core>3.27.0</version.org.assertj.assertj-core>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/search/hibernate-search-7/orm-elasticsearch/pom.xml
+++ b/search/hibernate-search-7/orm-elasticsearch/pom.xml
@@ -15,7 +15,7 @@
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
-		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
+		<version.org.assertj.assertj-core>3.27.0</version.org.assertj.assertj-core>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/search/hibernate-search-7/orm-lucene/pom.xml
+++ b/search/hibernate-search-7/orm-lucene/pom.xml
@@ -15,7 +15,7 @@
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
-		<version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
+		<version.org.assertj.assertj-core>3.27.0</version.org.assertj.assertj-core>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/validator/validator-9/pom.xml
+++ b/validator/validator-9/pom.xml
@@ -13,7 +13,7 @@
 		<version.org.hibernate.validator>9.0.0.CR1</version.org.hibernate.validator>
 		<version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
 		<version.log4j>2.24.3</version.log4j>
-		<version.assertj-core>3.26.3</version.assertj-core>
+		<version.assertj-core>3.27.0</version.assertj-core>
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
 	</properties>
 


### PR DESCRIPTION
Getting following exception when selecting embedded fields from union query wrapped in a criteria query.

`java.lang.NullPointerException: Cannot invoke "org.hibernate.metamodel.mapping.EmbeddableValuedModelPart.findSubPart(String, org.hibernate.metamodel.mapping.EntityMappingType)" because "modelPartContainer" is null
`