### PR TITLE
test case reproducer

### DIFF
--- a/orm/docker-compose.yml
+++ b/orm/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    container_name: postgres
+    hostname: postgres
+    image: postgis/postgis:16-3.5
+    environment:
+      POSTGRES_PASSWORD: 'password'
+      POSTGRES_USER: 'postgres'
+      POSTGRES_DB: 'database'
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    restart: always
+    networks:
+      - nw
+networks:
+  nw:
+    driver: bridge
+
+volumes:
+  postgres:

--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -38,12 +38,21 @@
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>com.h2database</groupId>-->
+<!--			<artifactId>h2</artifactId>-->
+<!--			<version>${version.com.h2database}</version>-->
+<!--		</dependency>-->
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<version>${version.com.h2database}</version>
+			<groupId>net.postgis</groupId>
+			<artifactId>postgis-jdbc</artifactId>
+			<version>2024.1.0</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.4</version>
+		</dependency>
 		<dependency>
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-testing</artifactId>
@@ -69,6 +78,16 @@
 			<artifactId>assertj-core</artifactId>
 			<version>${version.org.assertj.assertj-core}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-spatial</artifactId>
+			<version>6.6.3.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.18.2</version>
 		</dependency>
 	</dependencies>
 

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -1,5 +1,8 @@
 package org.hibernate.bugs;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.bugs.model.Point;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -7,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
+
+import java.util.List;
 
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using the Java Persistence API.
@@ -28,11 +33,36 @@ class JPAUnitTestCase {
 	// Entities are auto-discovered, so just add them anywhere on class-path
 	// Add your tests, using standard JUnit.
 	@Test
-	void hhh123Test() throws Exception {
+	void hhh18956Test() throws Exception {
 		EntityManager entityManager = entityManagerFactory.createEntityManager();
 		entityManager.getTransaction().begin();
-		// Do stuff...
+
+		final String query = createNativeQuery();
+		entityManager.createNativeQuery(query).executeUpdate();
 		entityManager.getTransaction().commit();
-		entityManager.close();
+
+		entityManager.close();;
 	}
+
+	private String createNativeQuery() throws JsonProcessingException {
+		final String nativeQuery = "INSERT INTO location (point) " +
+				"VALUES (%s) " +
+				"ON CONFLICT DO NOTHING;";
+
+		final String dollarQuotedGeoJsonValue = makeDollarQuotedValue();
+		return String.format(nativeQuery, dollarQuotedGeoJsonValue);
+	}
+
+	private String makeDollarQuotedValue() throws JsonProcessingException {
+		final String dollarQuote = "$asdas$";
+		final String postgisWrapper = "ST_SetSRID(ST_GeomFromGeoJSON(%s%s%s), 4326)";
+		return String.format(postgisWrapper, dollarQuote, makePoint(), dollarQuote);
+	}
+
+	private String makePoint() throws JsonProcessingException {
+		Point point = new Point(List.of(30.5, 50.4));
+		ObjectMapper objectMapper = new ObjectMapper();
+		return objectMapper.writeValueAsString(point);
+	}
+
 }

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
@@ -17,7 +17,7 @@ package org.hibernate.bugs;
 
 import org.hibernate.cfg.AvailableSettings;
 
-import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+//import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.Test;
 		}
 )
 @SessionFactory
-@BytecodeEnhanced
+//@BytecodeEnhanced
 class QuarkusLikeORMUnitTestCase {
 
 	// Add your tests, using standard JUnit.

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Location.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Location.java
@@ -1,0 +1,46 @@
+package org.hibernate.bugs.model;
+
+import jakarta.persistence.*;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Point point;
+
+    public Location() {
+    }
+
+    public Location(Long id, Point point) {
+        this.id = id;
+        this.point = point;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Point getPoint() {
+        return point;
+    }
+
+    public void setPoint(Point point) {
+        this.point = point;
+    }
+
+    @Override
+    public String toString() {
+        return "Location{" +
+                "id=" + id +
+                ", point=" + point +
+                '}';
+    }
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Point.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/model/Point.java
@@ -1,0 +1,26 @@
+package org.hibernate.bugs.model;
+
+import java.util.List;
+
+public class Point {
+
+    private String type;
+    private List<Double> coordinates;
+
+    public Point() {
+        type = "Point";
+    }
+
+    public Point(List<Double> coordinates) {
+        type = "Point";
+        this.coordinates = coordinates;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public List<Double> getCoordinates() {
+        return coordinates;
+    }
+}

--- a/orm/hibernate-orm-6/src/test/resources/META-INF/persistence.xml
+++ b/orm/hibernate-orm-6/src/test/resources/META-INF/persistence.xml
@@ -13,10 +13,11 @@
         <properties>
             <property name="hibernate.archive.autodetection" value="class, hbm"/>
 
-            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
-            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
-            <property name="hibernate.connection.username" value="sa"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.connection.driver_class" value="org.postgresql.Driver"/>
+            <property name="hibernate.connection.url" value="jdbc:postgresql://localhost:5432/database"/>
+            <property name="hibernate.connection.username" value="postgres"/>
+            <property name="hibernate.connection.password" value="password"/>
 
             <property name="hibernate.connection.pool_size" value="5"/>
 


### PR DESCRIPTION
This test fails when using Hibernate version 6.6.4.Final. However, it passes when downgrading to version 6.5.3.Final. Additional information about this issue can be found in the Atlassian ticket referenced.

The @BytecodeEnhanced annotation was commented out because it does not exist in version 6.5.3.Final.