### PR TITLE
Ignore JUnit's major/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,3 +50,5 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "org.elasticsearch.*:*"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "org.junit*:*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
Since orm test utils depend on JUnit to create the engine/extensions, we probably should stick to the ORM's version anyway...

