### PR TITLE
mssql bug with locking

### DIFF
--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/Entity1.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/Entity1.java
@@ -1,0 +1,57 @@
+package org.hibernate.bugs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class Entity1 {
+
+	@Column
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column
+	private String name;
+
+	@OneToOne
+	private Entity3 entity3;
+
+	public Entity1(Long id, Entity3 entity3) {
+		this.id = id;
+		this.entity3 = entity3;
+	}
+
+	public Entity1() {
+
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public Entity3 getEntity3() {
+		return entity3;
+	}
+
+	public void setEntity3(Entity3 entity3) {
+		this.entity3 = entity3;
+	}
+
+	@Override
+	public String toString() {
+		return "Entity1{" +
+				"id=" + id +
+				", name='" + name + '\'' +
+				", entity3=" + entity3 +
+				'}';
+	}
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/Entity2.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/Entity2.java
@@ -1,0 +1,49 @@
+package org.hibernate.bugs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
+public class Entity2 {
+
+	@Column
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column
+	private String name;
+
+	public Entity2() {
+
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Entity2(Long id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/Entity3.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/Entity3.java
@@ -1,0 +1,39 @@
+package org.hibernate.bugs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+@Entity
+public class Entity3 extends Entity2 {
+
+	@Column
+	private String surname;
+
+	public Entity3() {
+
+	}
+
+	public String getSurname() {
+		return surname;
+	}
+
+	public void setSurname(String surname) {
+		this.surname = surname;
+	}
+
+	public Entity3(String surname) {
+		this.surname = surname;
+	}
+
+	public Entity3(Long id, String name, String surname) {
+		super(id, name);
+		this.surname = surname;
+	}
+
+	@Override
+	public String toString() {
+		return "Entity3{" +
+				"surname='" + surname + '\'' +
+				'}';
+	}
+}

--- a/orm/hibernate-orm-6/src/test/resources/hibernate.properties
+++ b/orm/hibernate-orm-6/src/test/resources/hibernate.properties
@@ -5,16 +5,16 @@
 # See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 #
 
-hibernate.dialect org.hibernate.dialect.H2Dialect
+hibernate.dialect org.hibernate.dialect.SQLServerDialect
 hibernate.connection.driver_class org.h2.Driver
 #hibernate.connection.url jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE
-hibernate.connection.url jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1
+hibernate.connection.url jdbc:h2:mem:db1;MODE=MSSQLServer;DB_CLOSE_DELAY=-1
 hibernate.connection.username sa
 hibernate.connection.password 
 
 hibernate.connection.pool_size 5
 
-hibernate.show_sql false
+hibernate.show_sql true
 hibernate.format_sql true
 
 hibernate.max_fetch_depth 5


### PR DESCRIPTION
Jira issue: https://hibernate.atlassian.net/browse/HHH-19351
Description: https://discourse.hibernate.org/t/hibernate-sql-fails-on-syntax-error-with-when-locking-is-used/11342


NOTE:
I cannot be reproduced on H2 database even when compatibility mode with MSSQL is used.
But at least with this compatibility Hibernate generated the exact query that fails on real MSSQL database.