### PR TITLE
Set order_updates to `true` in Quarkus test template by default

### DIFF
--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/QuarkusLikeORMUnitTestCase.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Test;
 				@Setting(name = AvailableSettings.DEFAULT_NULL_ORDERING, value = "none"),
 				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true"),
 				@Setting(name = AvailableSettings.SEQUENCE_INCREMENT_SIZE_MISMATCH_STRATEGY, value = "none"),
+				@Setting(name = AvailableSettings.ORDER_UPDATES, value = "true"),
 
 				// Add your own settings that are a part of your quarkus configuration:
 				// @Setting( name = AvailableSettings.SOME_CONFIGURATION_PROPERTY, value = "SOME_VALUE" ),


### PR DESCRIPTION
Quarkus sets the `hibernate.order_updates` config property to `true` by default, unless explicitly specified in the PU settings:

https://github.com/quarkusio/quarkus/blob/fd4e51a62bfe5c17702d437bc96911becd74bf81/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java#L291-L294

Noticed while debugging this issue: https://github.com/quarkusio/quarkus/issues/47353