### PR TITLE
Ignore major/minor junit updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,7 @@ updates:
       # Major versions of vertx will (most likely) require a new version of Reactive, so will be updated "manually":
       - dependency-name: "io.vertx:*"
         update-types: [ "version-update:semver-major" ]
+      # Upgrading JUnit may break the ORM's bytecodeenhancement engine, hence major/minor updates are manual,
+      # when we perform an update to a new major/minor version of ORM.
+      - dependency-name: "org.junit:junit-bom"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
Hey @yrodiere 😃 

as I mentioned on some other pr... junit updates won't work fine with that bytecode test engine  (update to junit 5.13: https://github.com/hibernate/hibernate-orm/pull/10279). We rely on classes marked internal, if we don't we'd need to "fork entire jupiter" 🙈. I checked again and couldn't see any new extension points that we could leverage to do what we do in this engine... so let's just skip upgrading junit with dependabot and update it when we upadte it in orm ?

an alternative would be to publish hibernate-testing separately from orm and match the junit releases 😃.