### PR TITLE
HHH-19542: Order of nested embeddable determines secondary table to u…

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -79,7 +79,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.14.0</version>
 				<configuration>
-					<release>11</release>
+					<release>21</release>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMUnitTestCase.java
@@ -15,6 +15,7 @@
  */
 package org.hibernate.bugs;
 
+import org.hibernate.bugs.domain.model.Instrument;
 import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -23,6 +24,8 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 /**
  * This template demonstrates how to develop a test case for Hibernate ORM, using its built-in unit test framework.
@@ -36,8 +39,7 @@ import org.junit.jupiter.api.Test;
 @DomainModel(
 		annotatedClasses = {
 				// Add your entities here.
-				// Foo.class,
-				// Bar.class
+				Instrument.class
 		},
 		// If you use *.hbm.xml mappings, instead of annotations, add the mappings here.
 		xmlMappings = {
@@ -62,9 +64,10 @@ class ORMUnitTestCase {
 
 	// Add your tests, using standard JUnit 5.
 	@Test
-	void hhh123Test(SessionFactoryScope scope) throws Exception {
+	void hhh19542Test(SessionFactoryScope scope) throws Exception {
 		scope.inTransaction( session -> {
-			// Do stuff...
+			List<Instrument> instruments = session.createQuery("from Instrument ").list();
+			System.out.println(instruments);
 		} );
 	}
 }

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/model/CreditDerivative.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/model/CreditDerivative.java
@@ -1,0 +1,13 @@
+package org.hibernate.bugs.domain.model;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record CreditDerivative(
+        @AttributeOverride(name = "code", column = @Column(name = "CURRENCY_CODE", table = "INSTRUMENT_CREDIT_DERIVATIVE"))
+        CurrencyCode currencyCode,
+        @Column(name = "INDEX_SUB_FAMILY", table = "INSTRUMENT_CREDIT_DERIVATIVE")
+        String indexSubFamily) {
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/model/CurrencyCode.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/model/CurrencyCode.java
@@ -1,0 +1,17 @@
+package org.hibernate.bugs.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record CurrencyCode(
+        @Column(name = "CURRENCY_CODE")
+        String code) {
+
+    public CurrencyCode {
+        if (code == null || code.trim().isEmpty()) throw new IllegalArgumentException("Currency code must be provided.");
+        if (code.trim().length() != 3) throw new IllegalArgumentException("Currency code must have 3 characters.");
+
+        code = code.trim().toUpperCase().intern();
+    }
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/model/Instrument.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/domain/model/Instrument.java
@@ -1,0 +1,19 @@
+package org.hibernate.bugs.domain.model;
+
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "INSTRUMENT")
+@SecondaryTable(name = "INSTRUMENT_CREDIT_DERIVATIVE", pkJoinColumns = @PrimaryKeyJoinColumn(name = "INSTRUMENT_ID", referencedColumnName = "ID"))
+public abstract class Instrument {
+
+    @Id
+    @Column(name = "ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private CreditDerivative creditDerivative;
+
+}


### PR DESCRIPTION
HHH-19542 reproducer: org.hibernate.AnnotationException: Embeddable class 'org.hibernate.bugs.domain.model.CreditDerivative' has properties mapped to two different tables (all properties of the embeddable class must map to the same table)

https://hibernate.atlassian.net/browse/HHH-19542