### PR TITLE
Use different property names to deconfuse dependabot

### DIFF
--- a/envers/envers-7/pom.xml
+++ b/envers/envers-7/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <version.com.h2database>2.3.232</version.com.h2database>
         <version.junit>4.13.2</version.junit>
-        <version.org.hibernate.orm>7.0.2.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm7>7.0.2.Final</version.org.hibernate.orm7>
     </properties>
 
     <dependencyManagement>
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-platform</artifactId>
-                <version>${version.org.hibernate.orm}</version>
+                <version>${version.org.hibernate.orm7}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/orm/hibernate-orm-7/pom.xml
+++ b/orm/hibernate-orm-7/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.12.2</version.junit-jupiter>
-		<version.org.hibernate.orm>7.0.2.Final</version.org.hibernate.orm>
+		<version.org.hibernate.orm7>7.0.2.Final</version.org.hibernate.orm7>
 		<version.org.assertj.assertj-core>3.27.3</version.org.assertj.assertj-core>
 	</properties>
 
@@ -19,7 +19,7 @@
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-platform</artifactId>
-				<version>${version.org.hibernate.orm}</version>
+				<version>${version.org.hibernate.orm7}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-maven-plugin</artifactId>
-				<version>${version.org.hibernate.orm}</version>
+				<version>${version.org.hibernate.orm7}</version>
 				<executions>
 					<execution>
 						<configuration>

--- a/search/hibernate-search-8/orm-elasticsearch/pom.xml
+++ b/search/hibernate-search-8/orm-elasticsearch/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<version.org.hibernate.search>8.0.0.Final</version.org.hibernate.search>
-		<version.org.hibernate.orm>7.0.2.Final</version.org.hibernate.orm>
+		<version.org.hibernate.orm7>7.0.2.Final</version.org.hibernate.orm7>
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.12.2</version.junit-jupiter>
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-platform</artifactId>
-				<version>${version.org.hibernate.orm}</version>
+				<version>${version.org.hibernate.orm7}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/search/hibernate-search-8/orm-lucene/pom.xml
+++ b/search/hibernate-search-8/orm-lucene/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<version.org.hibernate.search>8.0.0.Final</version.org.hibernate.search>
-		<version.org.hibernate.orm>7.0.2.Final</version.org.hibernate.orm>
+		<version.org.hibernate.orm7>7.0.2.Final</version.org.hibernate.orm7>
 
 		<version.com.h2database>2.3.232</version.com.h2database>
 		<version.junit-jupiter>5.12.2</version.junit-jupiter>
@@ -38,7 +38,7 @@
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-platform</artifactId>
-				<version>${version.org.hibernate.orm}</version>
+				<version>${version.org.hibernate.orm7}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
https://github.com/hibernate/hibernate-test-case-templates/pull/533#discussion_r2149266207

tested this on the fork, and yeah, it seems that having the same property for different versions confuses Dependabot... changing the property name seems to help 