### PR TITLE
Remove unnecessary digits at the end of dependency version properties

### DIFF
--- a/envers/envers-7/pom.xml
+++ b/envers/envers-7/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <version.com.h2database>2.4.240</version.com.h2database>
         <version.junit>4.13.2</version.junit>
-        <version.org.hibernate.orm7>7.3.1.Final</version.org.hibernate.orm7>
+        <version.org.hibernate.orm>7.3.1.Final</version.org.hibernate.orm>
         <version.junit-jupiter>6.0.3</version.junit-jupiter>
     </properties>
 
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-platform</artifactId>
-                <version>${version.org.hibernate.orm7}</version>
+                <version>${version.org.hibernate.orm}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/orm/hibernate-orm-7/pom.xml
+++ b/orm/hibernate-orm-7/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<version.com.h2database>2.4.240</version.com.h2database>
 		<version.junit-jupiter>6.0.3</version.junit-jupiter>
-		<version.org.hibernate.orm7>7.3.1.Final</version.org.hibernate.orm7>
+		<version.org.hibernate.orm>7.3.1.Final</version.org.hibernate.orm>
 		<version.org.assertj.assertj-core>3.27.7</version.org.assertj.assertj-core>
 	</properties>
 
@@ -19,7 +19,7 @@
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-platform</artifactId>
-				<version>${version.org.hibernate.orm7}</version>
+				<version>${version.org.hibernate.orm}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -93,7 +93,7 @@
 			<plugin>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-maven-plugin</artifactId>
-				<version>${version.org.hibernate.orm7}</version>
+				<version>${version.org.hibernate.orm}</version>
 				<executions>
 					<execution>
 						<configuration>

--- a/reactive/hibernate-reactive-2/pom.xml
+++ b/reactive/hibernate-reactive-2/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <version.junit-jupiter>5.11.4</version.junit-jupiter>
-        <version.org.hibernate.reactive2>2.4.17.Final</version.org.hibernate.reactive2>
+        <version.org.hibernate.reactive>2.4.17.Final</version.org.hibernate.reactive>
         <version.org.assertj.assertj-core>3.27.7</version.org.assertj.assertj-core>
         <version.io.vertx.vertx-sql-client>4.5.26</version.io.vertx.vertx-sql-client>
         <version.org.testcontainers>2.0.4</version.org.testcontainers>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.hibernate.reactive</groupId>
             <artifactId>hibernate-reactive-core</artifactId>
-            <version>${version.org.hibernate.reactive2}</version>
+            <version>${version.org.hibernate.reactive}</version>
         </dependency>
 
         <!-- PostgreSQL -->

--- a/reactive/hibernate-reactive-3/pom.xml
+++ b/reactive/hibernate-reactive-3/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <version.junit-jupiter>5.11.4</version.junit-jupiter>
-        <version.org.hibernate.reactive3>3.3.3.Final</version.org.hibernate.reactive3>
+        <version.org.hibernate.reactive>3.3.3.Final</version.org.hibernate.reactive>
         <version.org.assertj.assertj-core>3.27.7</version.org.assertj.assertj-core>
         <version.io.vertx.vertx-sql-client>4.5.26</version.io.vertx.vertx-sql-client>
         <version.org.testcontainers>2.0.4</version.org.testcontainers>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.hibernate.reactive</groupId>
             <artifactId>hibernate-reactive-core</artifactId>
-            <version>${version.org.hibernate.reactive3}</version>
+            <version>${version.org.hibernate.reactive}</version>
         </dependency>
 
         <!-- PostgreSQL -->

--- a/reactive/hibernate-reactive-4/pom.xml
+++ b/reactive/hibernate-reactive-4/pom.xml
@@ -9,9 +9,9 @@
 
     <properties>
         <version.junit-jupiter>5.11.4</version.junit-jupiter>
-        <version.org.hibernate.reactive4>4.3.1.Final</version.org.hibernate.reactive4>
+        <version.org.hibernate.reactive>4.3.1.Final</version.org.hibernate.reactive>
         <version.org.assertj.assertj-core>3.27.7</version.org.assertj.assertj-core>
-        <version.io.vertx.vertx-sql-client5>5.0.10</version.io.vertx.vertx-sql-client5>
+        <version.io.vertx.vertx-sql-client>5.0.10</version.io.vertx.vertx-sql-client>
         <version.org.testcontainers>2.0.4</version.org.testcontainers>
     </properties>
 
@@ -38,14 +38,14 @@
         <dependency>
             <groupId>org.hibernate.reactive</groupId>
             <artifactId>hibernate-reactive-core</artifactId>
-            <version>${version.org.hibernate.reactive4}</version>
+            <version>${version.org.hibernate.reactive}</version>
         </dependency>
 
         <!-- PostgreSQL -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-pg-client</artifactId>
-            <version>${version.io.vertx.vertx-sql-client5}</version>
+            <version>${version.io.vertx.vertx-sql-client}</version>
         </dependency>
         <!-- Allow authentication to PostgreSQL using SCRAM -->
         <dependency>
@@ -58,28 +58,28 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-mysql-client</artifactId>
-            <version>${version.io.vertx.vertx-sql-client5}</version>
+            <version>${version.io.vertx.vertx-sql-client}</version>
         </dependency>
 
         <!-- DB2 -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-db2-client</artifactId>
-            <version>${version.io.vertx.vertx-sql-client5}</version>
+            <version>${version.io.vertx.vertx-sql-client}</version>
         </dependency>
 
         <!-- MSSQL -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-mssql-client</artifactId>
-            <version>${version.io.vertx.vertx-sql-client5}</version>
+            <version>${version.io.vertx.vertx-sql-client}</version>
         </dependency>
 
         <!-- Oracle -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-oracle-client</artifactId>
-            <version>${version.io.vertx.vertx-sql-client5}</version>
+            <version>${version.io.vertx.vertx-sql-client}</version>
         </dependency>
 
         <dependency>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <version>${version.io.vertx.vertx-sql-client5}</version>
+            <version>${version.io.vertx.vertx-sql-client}</version>
             <scope>test</scope>
         </dependency>
         <!-- Testcontainers -->

--- a/search/hibernate-search-7/orm-elasticsearch/pom.xml
+++ b/search/hibernate-search-7/orm-elasticsearch/pom.xml
@@ -8,7 +8,7 @@
 	<name>Hibernate Search 7 with Hibernate ORM and Elasticsearch Test Case Template</name>
 
 	<properties>
-		<version.org.hibernate.search7>7.2.6.Final</version.org.hibernate.search7>
+		<version.org.hibernate.search>7.2.6.Final</version.org.hibernate.search>
 		<version.org.hibernate.orm>6.6.48.Final</version.org.hibernate.orm>
 		<!-- Once ORM upgrade JBoss Logging to 3.6+ this can be removed -->
 		<version.jboss-logging>3.6.3.Final</version.jboss-logging>
@@ -41,7 +41,7 @@
 			<dependency>
 				<groupId>org.hibernate.search</groupId>
 				<artifactId>hibernate-search-bom</artifactId>
-				<version>${version.org.hibernate.search7}</version>
+				<version>${version.org.hibernate.search}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/search/hibernate-search-7/orm-lucene/pom.xml
+++ b/search/hibernate-search-7/orm-lucene/pom.xml
@@ -8,7 +8,7 @@
 	<name>Hibernate Search 7 with Hibernate ORM and Lucene Test Case Template</name>
 
 	<properties>
-		<version.org.hibernate.search7>7.2.6.Final</version.org.hibernate.search7>
+		<version.org.hibernate.search>7.2.6.Final</version.org.hibernate.search>
 		<version.org.hibernate.orm>6.6.48.Final</version.org.hibernate.orm>
 		<!-- Once ORM upgrade JBoss Logging to 3.6+ this can be removed -->
 		<version.jboss-logging>3.6.3.Final</version.jboss-logging>
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.hibernate.search</groupId>
 				<artifactId>hibernate-search-bom</artifactId>
-				<version>${version.org.hibernate.search7}</version>
+				<version>${version.org.hibernate.search}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/search/hibernate-search-8/orm-elasticsearch/pom.xml
+++ b/search/hibernate-search-8/orm-elasticsearch/pom.xml
@@ -8,8 +8,8 @@
 	<name>Hibernate Search 8 with Hibernate ORM and Elasticsearch Test Case Template</name>
 
 	<properties>
-		<version.org.hibernate.search8>8.3.0.Final</version.org.hibernate.search8>
-		<version.org.hibernate.orm7>7.3.1.Final</version.org.hibernate.orm7>
+		<version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
+		<version.org.hibernate.orm>7.3.1.Final</version.org.hibernate.orm>
 
 		<version.com.h2database>2.4.240</version.com.h2database>
 		<version.junit-jupiter>6.0.3</version.junit-jupiter>
@@ -39,14 +39,14 @@
 			<dependency>
 				<groupId>org.hibernate.search</groupId>
 				<artifactId>hibernate-search-bom</artifactId>
-				<version>${version.org.hibernate.search8}</version>
+				<version>${version.org.hibernate.search}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-platform</artifactId>
-				<version>${version.org.hibernate.orm7}</version>
+				<version>${version.org.hibernate.orm}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/search/hibernate-search-8/orm-lucene/pom.xml
+++ b/search/hibernate-search-8/orm-lucene/pom.xml
@@ -8,8 +8,8 @@
 	<name>Hibernate Search 8 with Hibernate ORM and Lucene Test Case Template</name>
 
 	<properties>
-		<version.org.hibernate.search8>8.3.0.Final</version.org.hibernate.search8>
-		<version.org.hibernate.orm7>7.3.1.Final</version.org.hibernate.orm7>
+		<version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
+		<version.org.hibernate.orm>7.3.1.Final</version.org.hibernate.orm>
 
 		<version.com.h2database>2.4.240</version.com.h2database>
 		<version.junit-jupiter>6.0.3</version.junit-jupiter>
@@ -31,14 +31,14 @@
 			<dependency>
 				<groupId>org.hibernate.search</groupId>
 				<artifactId>hibernate-search-bom</artifactId>
-				<version>${version.org.hibernate.search8}</version>
+				<version>${version.org.hibernate.search}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-platform</artifactId>
-				<version>${version.org.hibernate.orm7}</version>
+				<version>${version.org.hibernate.orm}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/validator/validator-8/pom.xml
+++ b/validator/validator-8/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.org.hibernate.validator8>8.0.3.Final</version.org.hibernate.validator8>
+		<version.org.hibernate.validator>8.0.3.Final</version.org.hibernate.validator>
 		<version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
 		<version.log4j>2.25.4</version.log4j>
 		<version.junit-jupiter>5.13.4</version.junit-jupiter>
@@ -32,12 +32,12 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>${version.org.hibernate.validator8}</version>
+			<version>${version.org.hibernate.validator}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator-test-utils</artifactId>
-			<version>${version.org.hibernate.validator8}</version>
+			<version>${version.org.hibernate.validator}</version>
 		</dependency>
 
 		<dependency>

--- a/validator/validator-9/pom.xml
+++ b/validator/validator-9/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.org.hibernate.validator9>9.1.0.Final</version.org.hibernate.validator9>
+		<version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
 		<version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
 		<version.log4j>2.25.4</version.log4j>
 		<version.assertj-core>3.27.7</version.assertj-core>
@@ -33,12 +33,12 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>${version.org.hibernate.validator9}</version>
+			<version>${version.org.hibernate.validator}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator-test-utils</artifactId>
-			<version>${version.org.hibernate.validator9}</version>
+			<version>${version.org.hibernate.validator}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
I confirmed it is not necessary by testing on my fork: https://github.com/yrodiere/hibernate-test-case-templates/pull/5/changes

It was initially introduced to avoid confusing dependabot, but it turns out the solution was to use `directories` instead:

https://github.com/hibernate/hibernate-test-case-templates/commit/f155f53df8c3ad43ff2295989830206755e7d35d