### PR TITLE
Add test-containers to a group in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,7 @@ updates:
           - "org.apache.logging*"
           - "com.h2database:*"
           - "org.assertj:*"
+          - "org.testcontainers:*"
     ignore:
       - dependency-name: "org.hibernate.orm.tooling:hibernate-enhance-maven-plugin"
       - dependency-name: "org.hibernate.orm.tooling:hibernate-testing"


### PR DESCRIPTION
To prevent Dependabot from sending one PR per directory

<img width="887" height="687" alt="image" src="https://github.com/user-attachments/assets/2a597844-3a6e-480b-86d2-ca7a33547193" />
