### PR TITLE
Change dependabot schedule to "weekly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - "search/**/*"
       - "validator/**/*"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       orm:
         patterns:


### PR DESCRIPTION
Because:

1. It's not like having test case templates up-to-date within 24 hours is super critical.
2. I'm fed up with the many notifications.

@marko-bekhta WDYT?