### PR TITLE
Bump org.hibernate.reactive:hibernate-reactive-core

### DIFF
--- a/reactive/hibernate-reactive-4/pom.xml
+++ b/reactive/hibernate-reactive-4/pom.xml
@@ -9,9 +9,9 @@
 
     <properties>
         <version.junit-jupiter>5.11.4</version.junit-jupiter>
-        <version.org.hibernate.reactive>4.4.1.Final</version.org.hibernate.reactive>
+        <version.org.hibernate.reactive>4.5.0.Final</version.org.hibernate.reactive>
         <version.org.assertj.assertj-core>3.27.7</version.org.assertj.assertj-core>
-        <version.io.vertx.vertx-sql-client>5.0.12</version.io.vertx.vertx-sql-client>
+        <version.io.vertx.vertx-sql-client>5.1.3</version.io.vertx.vertx-sql-client>
         <version.org.testcontainers>2.0.5</version.org.testcontainers>
     </properties>
 


### PR DESCRIPTION
Bumps the reactive group with 1 update in the /reactive/hibernate-reactive-4 directory: [org.hibernate.reactive:hibernate-reactive-core](https://github.com/hibernate/hibernate-reactive).

Updates `org.hibernate.reactive:hibernate-reactive-core` from 4.4.1.Final to 4.5.0.Final
- [Release notes](https://github.com/hibernate/hibernate-reactive/releases)
- [Commits](https://github.com/hibernate/hibernate-reactive/compare/4.4.1...4.5.0)

---
updated-dependencies:
- dependency-name: org.hibernate.reactive:hibernate-reactive-core dependency-version: 4.5.0.Final dependency-type: direct:production update-type: version-update:semver-minor dependency-group: reactive ...

Bump io.vertx:vertx-pg-client from 5.0.12 to 5.1.3

Bumps [io.vertx:vertx-pg-client](https://github.com/eclipse-vertx/vertx-sql-client) from 5.0.12 to 5.1.3.
- [Release notes](https://github.com/eclipse-vertx/vertx-sql-client/releases)
- [Changelog](https://github.com/eclipse-vertx/vertx-sql-client/blob/master/Changelog.md)
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/5.0.12...5.1.3)

---
updated-dependencies:
- dependency-name: io.vertx:vertx-pg-client dependency-version: 5.1.3 dependency-type: direct:production update-type: version-update:semver-minor ...