### PR TITLE
ORM 7: Set classesDirectory for bytecode enhancement plugin

### DIFF
--- a/orm/hibernate-orm-7/pom.xml
+++ b/orm/hibernate-orm-7/pom.xml
@@ -98,6 +98,7 @@
 					<execution>
 						<configuration>
 							<!-- Adjust the default configuration to your needs: -->
+							<classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
 							<enableAssociationManagement>false</enableAssociationManagement>
 							<enableExtendedEnhancement>false</enableExtendedEnhancement>
 							<enableDirtyTracking>false</enableDirtyTracking>


### PR DESCRIPTION
## Summary

- Set `<classesDirectory>` to `${project.build.testOutputDirectory}` in the `hibernate-maven-plugin` configuration

The plugin uses `classesDirectory` (default: `target/classes`) both as the classloader root and the base for computing class names from file paths. Since the `<fileSet>` already points to `target/test-classes`, the mismatch causes class names to be derived incorrectly when enhancement is enabled, producing errors like `Failed to enhance class sses.org.hibernate.bugs.TestEntity`.

## Test plan

- [x] Reproduced the failure by adding a `@Entity` class and enabling `enableDirtyTracking`/`enableLazyInitialization`
- [x] Verified the fix resolves the issue: `mvn clean test-compile` succeeds and the entity is enhanced

Closes #728