### PR TITLE
dirty-check-behavior:

### DIFF
--- a/orm/hibernate-orm-6/pom.xml
+++ b/orm/hibernate-orm-6/pom.xml
@@ -12,6 +12,7 @@
 		<version.junit-jupiter>5.11.4</version.junit-jupiter>
 		<version.org.hibernate.orm>6.6.54.Final</version.org.hibernate.orm>
 		<version.org.assertj.assertj-core>3.27.7</version.org.assertj.assertj-core>
+		<hibernate.enhance.enableDirtyTracking>true</hibernate.enhance.enableDirtyTracking>
 	</properties>
 
 	<dependencyManagement>
@@ -92,7 +93,7 @@
 							<base>${project.build.testOutputDirectory}</base>
 							<dir>${project.build.testOutputDirectory}</dir>
 							<enableAssociationManagement>false</enableAssociationManagement>
-							<enableDirtyTracking>false</enableDirtyTracking>
+							<enableDirtyTracking>${hibernate.enhance.enableDirtyTracking}</enableDirtyTracking>
 							<enableExtendedEnhancement>false</enableExtendedEnhancement>
 							<enableLazyInitialization>false</enableLazyInitialization>
 						</configuration>

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/DirtyCheckEntity.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/DirtyCheckEntity.java
@@ -1,0 +1,79 @@
+package org.hibernate.bugs;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.Objects;
+
+@Entity(name = "DirtyCheckEntity")
+@Table(name = "DIRTY_ENTITY")
+@Access(AccessType.PROPERTY)
+@DynamicUpdate
+@SequenceGenerator(
+        name = "DIRTY_ENTITY_SEQ_GENERATOR",
+        sequenceName = "DIRTY_ENTITY_SEQ",
+        allocationSize = 50
+)
+public class DirtyCheckEntity {
+
+    private Long id;
+    private Long version;
+    private String code;
+
+    public DirtyCheckEntity() {
+    }
+
+    @Id
+    @Column(name = "ID")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "TEST_ENTITY_SEQ_GENERATOR")
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        if (isChanged(this.id, id)) {
+            this.id = id;
+        }
+    }
+
+    @Version
+    @Column(name = "VERSION")
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        if (isChanged(this.version, version)) {
+            this.version = version;
+        }
+    }
+
+    @Basic
+    @Column(name = "CODE")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        if (isChanged(this.code, code)) {
+            this.code = code;
+        }
+    }
+
+    protected static boolean isChanged(Object currentValue, Object newValue) {
+        if (currentValue != null) {
+            return !Objects.equals(currentValue, newValue);
+        }
+        return newValue != null;
+    }
+}

--- a/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
+++ b/orm/hibernate-orm-6/src/test/java/org/hibernate/bugs/ORMStandaloneTestCase.java
@@ -1,5 +1,6 @@
 package org.hibernate.bugs;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
@@ -25,8 +26,7 @@ class ORMStandaloneTestCase {
 				.applySetting( "hibernate.hbm2ddl.auto", "update" );
 
 		Metadata metadata = new MetadataSources( srb.build() )
-				// Add your entities here.
-				//	.addAnnotatedClass( Foo.class )
+				.addAnnotatedClass(DirtyCheckEntity.class)
 				.buildMetadata();
 
 		sf = metadata.buildSessionFactory();
@@ -35,6 +35,12 @@ class ORMStandaloneTestCase {
 	// Add your tests, using standard JUnit 5:
 	@Test
 	void hhh123Test() throws Exception {
-
+		Session session = sf.openSession();
+		session.beginTransaction();
+		DirtyCheckEntity entity = new DirtyCheckEntity();
+		entity.setCode("test");
+		session.persist(entity);
+		session.getTransaction().commit();
+		session.close();
 	}
 }


### PR DESCRIPTION
orm/hibernate-orm-6

when enableDirtyTracking is false, only one insert  is generated
mvn clean test -Dtest=ORMStandaloneTestCase -Dhibernate.enhance.enableDirtyTracking=false -> insert 

when enableDirtyTracking is true, one insert  is generated, followed by a version update
mvn clean test -Dtest=ORMStandaloneTestCase -> insert and update
